### PR TITLE
feat: add registry-aware template workflow and modernize CLI tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ c-copy --help
 create-copy --help
 ```
 
+如果你要在 Node.js 中以代码方式调用这个包，请注意当前版本只提供 ESM 导出，不再提供 CommonJS 的 `require(...)` 入口。
+
 ## 快速开始
 
 ```bash
@@ -274,6 +276,24 @@ c-copy create -t vue3-template my-app
 5. 离线模式下只会使用与当前注册表配置匹配的缓存
 
 如果你曾在旧缓存里遇到过类似 https://raw.githubusercontent.com/unjs/giget/main/templates/undefined.json 的请求错误，执行 c-copy update 即可重写 ~/.ccopyrc。当前版本会在读取缓存时自动忽略历史上遗留的 undefined 和 null 字符串值。
+
+## 程序化调用
+
+除了 CLI 之外，也可以在 ESM 环境里直接调用包导出的运行入口：
+
+```ts
+import { runCommand, runMain } from 'create-copy'
+
+await runCommand('create', ['create', '--template', 'vue3-template', 'demo'])
+
+runMain()
+```
+
+说明：
+
+- 仅支持 ESM `import`
+- 不支持 CommonJS `require('create-copy')`
+- 构建产物默认输出 `dist/index.mjs` 和类型声明文件，不再生成 `dist/index.cjs`
 
 ## 开发
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ c-copy create [options] [name]
 | name | 目标目录名，不传时默认使用模板名 |
 | -u, --url <url> | 直接下载模板 URL，传入后会跳过注册表查找 |
 | -t, --template <name> | 指定模板名；不传时进入交互选择 |
-| -f, --force | 创建前刷新模板注册表 |
+| -f, --force | 创建前刷新模板注册表，并强制刷新模板下载 |
 | -o, --offline | 仅使用本地缓存，不发起网络请求 |
 | --cwd <dir> | 指定项目生成目录；相对路径基于命令发起目录解析 |
 | --logLevel <level> | 指定日志级别，支持 silent、fatal、error、warn、log、info、debug、trace、verbose 或数字级别 |
@@ -105,6 +105,7 @@ c-copy create [options] [name]
 - 使用 --offline 时不能切换到另一个尚未缓存的注册表来源
 - 目标目录已存在时，CLI 会提示是否继续，并在确认后清理该目录
 - 如果当前注册表来源与缓存记录不一致，create 会自动刷新缓存后再创建项目
+- 传入 --force 时，create 会刷新模板注册表，并把强制刷新标记透传给 giget 模板下载
 - create 的默认基准目录是命令发起目录；通过 pnpm c-copy create 调用时会优先使用 INIT_CWD，其次使用 PWD，最后才回退到进程当前目录
 - 未传入 name 时，会依次使用 --url 推导目录名、模板的 defaultDir 和模板 value 作为目标目录名
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ c-copy 是一个基于 citty 和 giget 的命令行工具，用来从远程模�
 
 ## 环境要求
 
-- 运行 CLI：Node.js >= 22.9
-- 开发和运行测试：Node.js >= 22.12
+- 安装和运行 CLI：Node.js >= 22.9（与 package.json 中的 engines.node 保持一致）
+- 开发和运行测试：Node.js >= 22.12（当前开发工具链需要更高的补丁版本；如果只是使用 CLI，无需满足这一项）
 - 建议使用 pnpm 或 npm 安装
 
 ## 安装

--- a/README.md
+++ b/README.md
@@ -1,64 +1,241 @@
-# c-copy 通过命令行创建模版项目
+# c-copy
 
-[模版地址](https://github.com/xjccc-team/template-infos/blob/main/templates.json)
+c-copy 是一个基于 citty 和 giget 的命令行工具，用来从远程模板注册表快速生成本地项目。注册表可以放在 GitHub、GitLab、Gitee 或任意可访问的原始文件 URL 上，CLI 会把模板清单缓存到本机，并统一处理模板选择、下载、更新和清理。
 
-* nuxt3-template
-* vue3-template
-* vue2-template
+## 功能特性
 
-> 第一次获取json默认数据，会生成一个`__temp__`文件夹（用完即删），根目录 `/User/xxx/.ccopyrc` 存储json数据
+- 支持从 GitHub、GitLab、Gitee 或直接 URL 加载模板注册表
+- 首次使用自动拉取模板注册表并缓存到 ~/.ccopyrc
+- 支持交互式模板选择，也支持命令行直接指定模板
+- 支持离线模式，复用 giget 的本地缓存
+- 切换注册表来源时会自动刷新缓存，避免误用旧模板
+- 提供 show、update、clean 命令管理模板缓存
+- 同时提供 c-copy 和 create-copy 两个命令名
 
-## install
+## 环境要求
+
+- 运行 CLI：Node.js >= 22.9
+- 开发和运行测试：Node.js >= 22.12
+- 建议使用 pnpm 或 npm 安装
+
+## 安装
 
 ```bash
-pnpm install create-copy -g
+pnpm add -g create-copy
 ```
 
-
-## usage
-
-c-copy create [OPTIONS] [NAME]
-
-default options with `cwd` & `logLevel`
-
-All this commands could use `--help` for more infomations
-
-## commands
-
-#### create
-
-create project with subcommands
- - template/t
- - force/f
- - offline/o
- - name
-
-#### show
-
-show cached json `.ccopyrc`
-
-#### clean
-
-clean cached json `.ccopyrc` & `.cache/giget`
+或：
 
 ```bash
-# 显示存储json信息 .ccopyrc
+npm install -g create-copy
+```
+
+安装后可以使用任一命令：
+
+```bash
+c-copy --help
+create-copy --help
+```
+
+## 快速开始
+
+```bash
+# 交互式选择模板，并使用模板名作为目录名
+c-copy create
+
+# 指定模板和项目目录
+c-copy create -t vue3-template my-app
+
+# 在指定目录下创建项目
+c-copy create -t nuxt3-template --cwd ../workspace my-app
+
+# 通过 pnpm 从子目录调用时，默认仍创建到命令发起目录
+pnpm c-copy create -t vue3-template my-app
+```
+
+创建完成后，终端会提示进入目录并安装依赖：
+
+```bash
+cd my-app && pnpm install
+```
+
+## 命令说明
+
+### create
+
+创建一个新项目。
+
+```bash
+c-copy create [options] [name]
+```
+
+参数说明：
+
+| 参数 | 说明 |
+| --- | --- |
+| name | 目标目录名，不传时默认使用模板名 |
+| -t, --template <name> | 指定模板名；不传时进入交互选择 |
+| -f, --force | 创建前刷新模板注册表 |
+| -o, --offline | 仅使用本地缓存，不发起网络请求 |
+| --cwd <dir> | 指定项目生成目录；相对路径基于命令发起目录解析 |
+| --logLevel <level> | 指定日志级别，支持 silent、fatal、error、warn、log、info、debug、trace、verbose 或数字级别 |
+| -r, --registryUrl <url> | 直接指定模板注册表 URL |
+| --registryProvider <provider> | 指定注册表提供方，支持 github、gitlab、gitee、url |
+| --registryRepo <repo> | 指定注册表仓库路径，例如 xjccc-team/template-infos |
+| --registryBranch <branch> | 指定注册表分支或 ref |
+| --registryFile <file> | 指定注册表文件路径 |
+
+说明：
+
+- --force 和 --offline 不能同时使用
+- 使用 --offline 时，本机必须已经存在 ~/.ccopyrc 和 giget 模板缓存
+- 使用 --offline 时不能切换到另一个尚未缓存的注册表来源
+- 目标目录已存在时，CLI 会提示是否继续，并在确认后清理该目录
+- 如果当前注册表来源与缓存记录不一致，create 会自动刷新缓存后再创建项目
+- create 的默认基准目录是命令发起目录；通过 pnpm c-copy create 调用时会优先使用 INIT_CWD，其次使用 PWD，最后才回退到进程当前目录
+- 未传入 name 时，会依次使用模板的 defaultDir 和模板 value 作为目标目录名
+
+### show
+
+查看本地缓存的模板注册表和其来源元信息。
+
+```bash
 c-copy show
-# 删除存储的json文件 - 删除.ccopyrc
-c-copy clean
-# 创建模版
-c-copy create xxx
-c-copy create --template vue2-template xxx
-# 创建时使用最新json数据
-c-copy create -t vue2-template -f
-# 下载到对应目录
-c-copy create -t vue2-template --cwd ../../example
-
 ```
 
-# respect
+### update
 
-1. Vue
-2. vue-cli
-3. Nuxt
-4. UnJS
+从远端模板注册表重新拉取最新配置，并更新到 ~/.ccopyrc。
+
+```bash
+c-copy update
+```
+
+`update` 同样支持 `--registryUrl`、`--registryProvider`、`--registryRepo`、`--registryBranch`、`--registryFile` 这些参数。
+
+### clean
+
+清理本地缓存的模板注册表和 giget 模板缓存。
+
+```bash
+c-copy clean
+```
+
+## 使用示例
+
+```bash
+# 使用交互模式创建项目
+c-copy create
+
+# 使用指定模板创建项目
+c-copy create --template vue2-template demo-vue2
+
+# 创建前刷新模板清单和模板内容
+c-copy create -t vue3-template demo-vue3 --force
+
+# 使用本地缓存离线创建
+c-copy create -t nuxt3-template demo-nuxt --offline
+
+# 使用 GitLab 上的注册表
+c-copy create -t vue3-template demo-gitlab --registryProvider gitlab --registryRepo your-group/template-infos
+
+# 使用 Gitee 上的注册表
+c-copy create -t vue3-template demo-gitee --registryProvider gitee --registryRepo your-org/template-infos
+
+# 使用直接 URL 作为注册表来源
+c-copy update --registryUrl https://example.com/templates.json
+
+# 查看当前缓存的模板列表
+c-copy show
+
+# 手动更新模板注册表
+c-copy update
+
+# 清理所有本地缓存
+c-copy clean
+```
+
+## 模板注册表与缓存
+
+默认注册表来源：
+
+```text
+https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json
+```
+
+支持两种配置方式：
+
+1. 通过命令参数临时切换
+2. 通过环境变量设置默认值
+
+可用环境变量：
+
+| 变量名 | 说明 |
+| --- | --- |
+| C_COPY_REGISTRY_URL | 直接指定注册表 URL，优先级最高 |
+| C_COPY_REGISTRY_PROVIDER | 注册表提供方，支持 github、gitlab、gitee |
+| C_COPY_REGISTRY_REPO | 注册表仓库路径 |
+| C_COPY_REGISTRY_BRANCH | 注册表分支或 ref |
+| C_COPY_REGISTRY_FILE | 注册表文件路径 |
+
+例如：
+
+```bash
+export C_COPY_REGISTRY_PROVIDER=gitlab
+export C_COPY_REGISTRY_REPO=your-group/template-infos
+export C_COPY_REGISTRY_BRANCH=main
+
+c-copy create -t vue3-template my-app
+```
+
+注册表中的每一项通常包含以下字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| name | 模板名称，兼容 giget TemplateInfo，通常与 value 保持一致 |
+| label | 交互选择时展示的名称 |
+| value | 模板唯一标识，也是命令行里传给 --template 的值；未提供时会回退到 name |
+| hint | 模板提示信息 |
+| url | 模板仓库地址 |
+| tar | 模板 tarball 下载地址 |
+| source | 可选，自定义 giget 模板源，例如 gitlab:group/project |
+| defaultDir | 可选，未传 name 时创建项目的默认目录名 |
+
+下载模板时，c-copy 会按以下顺序选择下载源：
+
+1. source
+2. tar
+3. url，会被当作 git 仓库地址转换成 giget 的 git:url 形式
+4. 如果以上字段都不存在，回退到 github:xjccc-team/<template>
+
+本地缓存位置：
+
+- ~/.ccopyrc：模板注册表缓存，包含模板数据和注册表来源元信息
+- ~/.cache/giget：giget 下载后的模板缓存
+
+工作流程：
+
+1. 执行 create 时，优先读取 ~/.ccopyrc
+2. 如果本地没有缓存、传入 --force，或当前注册表来源与缓存记录不一致，会重新拉取远端模板注册表
+3. 选择模板后，通过 giget 下载并解压模板内容
+4. 模板缓存会保留在 ~/.cache/giget，供后续离线创建复用
+5. 离线模式下只会使用与当前注册表配置匹配的缓存
+
+如果你曾在旧缓存里遇到过类似 https://raw.githubusercontent.com/unjs/giget/main/templates/undefined.json 的请求错误，执行 c-copy update 即可重写 ~/.ccopyrc。当前版本会在读取缓存时自动忽略历史上遗留的 undefined 和 null 字符串值。
+
+## 开发
+
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+pnpm build
+node ./bin/c-copy.mjs --help
+```
+
+## 致谢
+
+- Vue
+- vue-cli
+- Nuxt
+- UnJS

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ c-copy 是一个基于 citty 和 giget 的命令行工具，用来从远程模�
 - 支持从 GitHub、GitLab、Gitee 或直接 URL 加载模板注册表
 - 首次使用自动拉取模板注册表并缓存到 ~/.ccopyrc
 - 支持交互式模板选择，也支持命令行直接指定模板
+- 支持在 create 命令中通过 URL 直接下载模板
+- 支持通过 download 命令直接从 URL 下载模板到指定目录
 - 支持离线模式，复用 giget 的本地缓存
 - 切换注册表来源时会自动刷新缓存，避免误用旧模板
-- 提供 show、update、clean 命令管理模板缓存
+- 提供 download、show、update、clean 命令管理模板缓存和直连下载
 - 同时提供 c-copy 和 create-copy 两个命令名
 
 ## 环境要求
@@ -49,6 +51,12 @@ c-copy create -t vue3-template my-app
 # 在指定目录下创建项目
 c-copy create -t nuxt3-template --cwd ../workspace my-app
 
+# 在 create 中直接从 URL 下载模板
+c-copy create --url https://github.com/your-org/template.git my-app
+
+# 直接从 URL 下载模板到指定目录
+c-copy download --url https://github.com/your-org/template.git my-app
+
 # 通过 pnpm 从子目录调用时，默认仍创建到命令发起目录
 pnpm c-copy create -t vue3-template my-app
 ```
@@ -74,6 +82,7 @@ c-copy create [options] [name]
 | 参数 | 说明 |
 | --- | --- |
 | name | 目标目录名，不传时默认使用模板名 |
+| -u, --url <url> | 直接下载模板 URL，传入后会跳过注册表查找 |
 | -t, --template <name> | 指定模板名；不传时进入交互选择 |
 | -f, --force | 创建前刷新模板注册表 |
 | -o, --offline | 仅使用本地缓存，不发起网络请求 |
@@ -88,12 +97,42 @@ c-copy create [options] [name]
 说明：
 
 - --force 和 --offline 不能同时使用
+- --url 与 --template 不能同时使用
+- --url 与任何 --registry* 参数不能同时使用
+- 传入 --url 后，create 会跳过注册表缓存逻辑，直接下载目标 URL 内容
+- 传入以 .tar.gz、.tgz、.zip 结尾的 URL 时，会按归档包直接下载
 - 使用 --offline 时，本机必须已经存在 ~/.ccopyrc 和 giget 模板缓存
 - 使用 --offline 时不能切换到另一个尚未缓存的注册表来源
 - 目标目录已存在时，CLI 会提示是否继续，并在确认后清理该目录
 - 如果当前注册表来源与缓存记录不一致，create 会自动刷新缓存后再创建项目
 - create 的默认基准目录是命令发起目录；通过 pnpm c-copy create 调用时会优先使用 INIT_CWD，其次使用 PWD，最后才回退到进程当前目录
-- 未传入 name 时，会依次使用模板的 defaultDir 和模板 value 作为目标目录名
+- 未传入 name 时，会依次使用 --url 推导目录名、模板的 defaultDir 和模板 value 作为目标目录名
+
+### download
+
+从指定 URL 直接下载模板内容。
+
+```bash
+c-copy download --url <url> [options] [name]
+```
+
+参数说明：
+
+| 参数 | 说明 |
+| --- | --- |
+| name | 目标目录名，不传时根据 URL 自动推导 |
+| -u, --url <url> | 必填，直接下载的模板 URL |
+| -f, --force | 下载前刷新模板内容 |
+| -o, --offline | 仅使用 giget 本地缓存 |
+| --cwd <dir> | 指定项目生成目录；相对路径基于命令发起目录解析 |
+| --logLevel <level> | 指定日志级别，支持 silent、fatal、error、warn、log、info、debug、trace、verbose 或数字级别 |
+
+说明：
+
+- --force 和 --offline 不能同时使用
+- 传入仓库 URL 时，会按 git 仓库形式下载
+- 传入以 .tar.gz、.tgz、.zip 结尾的 URL 时，会按归档包直接下载
+- 未传入 name 时，会优先从仓库名或归档所在仓库名推导目标目录
 
 ### show
 
@@ -144,6 +183,18 @@ c-copy create -t vue3-template demo-gitee --registryProvider gitee --registryRep
 
 # 使用直接 URL 作为注册表来源
 c-copy update --registryUrl https://example.com/templates.json
+
+# 在 create 中直接下载 Git 仓库模板
+c-copy create --url https://github.com/your-org/template.git my-app
+
+# 在 create 中直接下载归档模板
+c-copy create --url https://github.com/your-org/template/archive/refs/heads/main.tar.gz
+
+# 直接下载 Git 仓库模板
+c-copy download --url https://github.com/your-org/template.git my-app
+
+# 直接下载归档模板
+c-copy download --url https://github.com/your-org/template/archive/refs/heads/main.tar.gz
 
 # 查看当前缓存的模板列表
 c-copy show

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-copy",
-  "version": "0.0.11",
-  "description": "cli for vue default config template",
+  "version": "1.0.0",
+  "description": "CLI for downloading preconfigured project templates from remote registries",
   "main": "./dist/index.mjs",
   "type": "module",
   "types": "./dist/index.d.ts",
@@ -19,14 +19,25 @@
     "dist",
     "bin"
   ],
+  "engines": {
+    "node": ">=22.9.0"
+  },
   "scripts": {
     "build": "unbuild",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "giget": "jiti ./src/index.ts",
     "c-copy": "node ./bin/c-copy.mjs",
     "release": "pnpm build && changelogen --release && npm publish && git push --follow-tags"
   },
   "keywords": [
-    "c-copy"
+    "c-copy",
+    "cli",
+    "template",
+    "scaffold",
+    "giget",
+    "citty"
   ],
   "homepage": "https://github.com/xjccc/c-copy",
   "author": "xjccc <https://github.com/xjccc>",
@@ -36,18 +47,20 @@
   },
   "license": "MIT",
   "dependencies": {
-    "citty": "^0.1.6",
+    "citty": "^0.2.2",
     "consola": "^3.4.2",
-    "giget": "^2.0.0",
-    "ini": "^5.0.0",
+    "giget": "^3.2.0",
+    "ini": "^6.0.0",
     "pathe": "^2.0.3"
   },
   "devDependencies": {
     "@types/ini": "^4.1.1",
-    "@types/node": "^22.16.5",
+    "@types/node": "^25.6.0",
     "changelogen": "^0.6.2",
-    "jiti": "^2.4.2",
-    "typescript": "^5.8.3",
-    "unbuild": "^3.5.0"
+    "jiti": "^2.6.1",
+    "typescript": "^6.0.2",
+    "unbuild": "^3.6.1",
+    "vite": "^8.0.8",
+    "vitest": "^4.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "create-copy": "./bin/c-copy.mjs"
   },
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    }
+    "default": "./dist/index.mjs"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,521 +1,350 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  citty:
-    specifier: ^0.1.6
-    version: 0.1.6
-  consola:
-    specifier: ^3.4.2
-    version: 3.4.2
-  giget:
-    specifier: ^2.0.0
-    version: 2.0.0
-  ini:
-    specifier: ^5.0.0
-    version: 5.0.0
-  pathe:
-    specifier: ^2.0.3
-    version: 2.0.3
+importers:
 
-devDependencies:
-  '@types/ini':
-    specifier: ^4.1.1
-    version: 4.1.1
-  '@types/node':
-    specifier: ^22.16.5
-    version: 22.16.5
-  changelogen:
-    specifier: ^0.6.2
-    version: 0.6.2
-  jiti:
-    specifier: ^2.4.2
-    version: 2.4.2
-  typescript:
-    specifier: ^5.8.3
-    version: 5.8.3
-  unbuild:
-    specifier: ^3.5.0
-    version: 3.5.0(typescript@5.8.3)
+  .:
+    dependencies:
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+      giget:
+        specifier: ^3.2.0
+        version: 3.2.0
+      ini:
+        specifier: ^6.0.0
+        version: 6.0.0
+      pathe:
+        specifier: ^2.0.3
+        version: 2.0.3
+    devDependencies:
+      '@types/ini':
+        specifier: ^4.1.1
+        version: 4.1.1
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      changelogen:
+        specifier: ^0.6.2
+        version: 0.6.2
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      unbuild:
+        specifier: ^3.6.1
+        version: 3.6.1(typescript@6.0.2)
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
 
-  /@babel/code-frame@7.26.2:
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
-    requiresBuild: true
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-    dev: true
-    optional: true
 
-  /@babel/helper-validator-identifier@7.25.9:
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/aix-ppc64@0.24.2:
-    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+  '@colordx/core@5.0.3':
+    resolution: {integrity: sha512-xBQ0MYRTNNxW3mS2sJtlQTT7C3Sasqgh1/PsHva7fyDb5uqYY+gv9V0utDdX8X80mqzbGz3u/IDJdn2d/uW09g==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/aix-ppc64@0.25.0:
-    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm64@0.24.2:
-    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm64@0.25.0:
-    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.24.2:
-    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm@0.25.0:
-    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.24.2:
-    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-x64@0.25.0:
-    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.24.2:
-    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-arm64@0.25.0:
-    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.24.2:
-    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-x64@0.25.0:
-    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.24.2:
-    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-arm64@0.25.0:
-    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.24.2:
-    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-x64@0.25.0:
-    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.24.2:
-    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm64@0.25.0:
-    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.24.2:
-    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm@0.25.0:
-    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.24.2:
-    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ia32@0.25.0:
-    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.24.2:
-    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-loong64@0.25.0:
-    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.24.2:
-    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-mips64el@0.25.0:
-    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.24.2:
-    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ppc64@0.25.0:
-    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-riscv64@0.24.2:
-    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.25.0:
-    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.24.2:
-    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
-    engines: {node: '>=18'}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-s390x@0.25.0:
-    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.24.2:
-    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
-    engines: {node: '>=18'}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-x64@0.25.0:
-    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==}
-    engines: {node: '>=18'}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-arm64@0.24.2:
-    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
-    engines: {node: '>=18'}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
+    os: [openharmony]
 
-  /@esbuild/netbsd-arm64@0.25.0:
-    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
 
-  /@esbuild/netbsd-x64@0.24.2:
-    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.25.0:
-    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-arm64@0.24.2:
-    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-arm64@0.25.0:
-    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.24.2:
-    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.25.0:
-    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.24.2:
-    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.25.0:
-    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.24.2:
-    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
-    engines: {node: '>=18'}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-arm64@0.25.0:
-    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.24.2:
-    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.25.0:
-    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.24.2:
-    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
-    engines: {node: '>=18'}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-x64@0.25.0:
-    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
-  /@jridgewell/sourcemap-codec@1.5.0:
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-    dev: true
-
-  /@rollup/plugin-alias@5.1.1(rollup@4.34.8):
+  '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -523,30 +352,17 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      rollup: 4.34.8
-    dev: true
 
-  /@rollup/plugin-commonjs@28.0.2(rollup@4.34.8):
-    resolution: {integrity: sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==}
+  '@rollup/plugin-commonjs@28.0.9':
+    resolution: {integrity: sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
       rollup: ^2.68.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      fdir: 6.4.2(picomatch@4.0.2)
-      is-reference: 1.2.1
-      magic-string: 0.30.17
-      picomatch: 4.0.2
-      rollup: 4.34.8
-    dev: true
 
-  /@rollup/plugin-json@6.1.0(rollup@4.34.8):
+  '@rollup/plugin-json@6.1.0':
     resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -554,799 +370,601 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
-      rollup: 4.34.8
-    dev: true
 
-  /@rollup/plugin-node-resolve@16.0.0(rollup@4.34.8):
-    resolution: {integrity: sha512-0FPvAeVUT/zdWoO0jnb/V5BlBsUSNfkIOtFHzMO4H9MOklrmQFY6FduVHKucNb/aTFxvnGhj4MNj/T1oNdDfNg==}
+  '@rollup/plugin-node-resolve@16.0.3':
+    resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-module: 1.0.0
-      resolve: 1.22.8
-      rollup: 4.34.8
-    dev: true
 
-  /@rollup/plugin-replace@6.0.2(rollup@4.34.8):
-    resolution: {integrity: sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==}
+  '@rollup/plugin-replace@6.0.3':
+    resolution: {integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
-      magic-string: 0.30.17
-      rollup: 4.34.8
-    dev: true
 
-  /@rollup/pluginutils@5.1.4(rollup@4.34.8):
-    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
-      rollup: 4.34.8
-    dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.34.8:
-    resolution: {integrity: sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==}
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-android-arm64@4.34.8:
-    resolution: {integrity: sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==}
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-arm64@4.34.8:
-    resolution: {integrity: sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==}
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-x64@4.34.8:
-    resolution: {integrity: sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==}
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-freebsd-arm64@4.34.8:
-    resolution: {integrity: sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==}
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-freebsd-x64@4.34.8:
-    resolution: {integrity: sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==}
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.34.8:
-    resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.34.8:
-    resolution: {integrity: sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.34.8:
-    resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.34.8:
-    resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-loongarch64-gnu@4.34.8:
-    resolution: {integrity: sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.34.8:
-    resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.34.8:
-    resolution: {integrity: sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.34.8:
-    resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.34.8:
-    resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.34.8:
-    resolution: {integrity: sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==}
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.34.8:
-    resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.34.8:
-    resolution: {integrity: sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.34.8:
-    resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@trysound/sax@0.2.0:
-    resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
-    engines: {node: '>=10.13.0'}
-    dev: true
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
 
-  /@types/estree@1.0.6:
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-    dev: true
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  /@types/ini@4.1.1:
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/ini@4.1.1':
     resolution: {integrity: sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==}
-    dev: true
 
-  /@types/node@22.16.5:
-    resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
-    dependencies:
-      undici-types: 6.21.0
-    dev: true
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
-  /@types/resolve@1.20.2:
+  '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
-    dev: true
 
-  /acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: true
 
-  /autoprefixer@10.4.20(postcss@8.4.49):
-    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
-    dependencies:
-      browserslist: 4.24.3
-      caniuse-lite: 1.0.30001688
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
 
-  /boolbase@1.0.0:
+  baseline-browser-mapping@2.10.18:
+    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-    dev: true
 
-  /browserslist@4.24.3:
-    resolution: {integrity: sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001688
-      electron-to-chromium: 1.5.73
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.1(browserslist@4.24.3)
-    dev: true
 
-  /bundle-name@4.1.0:
+  bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-    dependencies:
-      run-applescript: 7.0.0
-    dev: true
 
-  /c12@3.0.4:
-    resolution: {integrity: sha512-t5FaZTYbbCtvxuZq9xxIruYydrAGsJ+8UdP0pZzMiK2xl/gNiSOy0OxhLzHUEEb0m1QXYqfzfvyIFEmz/g9lqg==}
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
     peerDependencies:
-      magicast: ^0.3.5
+      magicast: '*'
     peerDependenciesMeta:
       magicast:
         optional: true
-    dependencies:
-      chokidar: 4.0.3
-      confbox: 0.2.2
-      defu: 6.1.4
-      dotenv: 16.6.1
-      exsolve: 1.0.7
-      giget: 2.0.0
-      jiti: 2.4.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 1.0.0
-      pkg-types: 2.2.0
-      rc9: 2.1.2
-    dev: true
 
-  /caniuse-api@3.0.0:
+  caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
-    dependencies:
-      browserslist: 4.24.3
-      caniuse-lite: 1.0.30001688
-      lodash.memoize: 4.1.2
-      lodash.uniq: 4.5.0
-    dev: true
 
-  /caniuse-lite@1.0.30001688:
-    resolution: {integrity: sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==}
-    dev: true
+  caniuse-lite@1.0.30001787:
+    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
-  /changelogen@0.6.2:
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  changelogen@0.6.2:
     resolution: {integrity: sha512-QtC7+r9BxoUm+XDAwhLbz3CgU134J1ytfE3iCpLpA4KFzX2P1e6s21RrWDwUBzfx66b1Rv+6lOA2nS2btprd+A==}
     hasBin: true
-    dependencies:
-      c12: 3.0.4
-      confbox: 0.2.2
-      consola: 3.4.2
-      convert-gitmoji: 0.1.5
-      mri: 1.2.0
-      node-fetch-native: 1.6.6
-      ofetch: 1.4.1
-      open: 10.1.2
-      pathe: 2.0.3
-      pkg-types: 2.2.0
-      scule: 1.3.0
-      semver: 7.7.2
-      std-env: 3.9.0
-    transitivePeerDependencies:
-      - magicast
-    dev: true
 
-  /chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-    dependencies:
-      readdirp: 4.1.2
-    dev: true
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
-  /citty@0.1.6:
+  citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
-    dependencies:
-      consola: 3.4.2
 
-  /colord@2.9.3:
-    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
-    dev: true
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
-  /commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
-    dev: true
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
-  /commondir@1.0.1:
+  commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-    dev: true
 
-  /confbox@0.1.8:
+  confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
-  /confbox@0.2.2:
-    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
-    dev: true
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
-  /consola@3.4.2:
+  consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  /convert-gitmoji@0.1.5:
+  convert-gitmoji@0.1.5:
     resolution: {integrity: sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ==}
-    dev: true
 
-  /css-declaration-sorter@7.2.0(postcss@8.4.49):
-    resolution: {integrity: sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==}
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css-declaration-sorter@7.4.0:
+    resolution: {integrity: sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
-    dependencies:
-      postcss: 8.4.49
-    dev: true
 
-  /css-select@5.1.0:
-    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.1.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-      nth-check: 2.1.1
-    dev: true
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
-  /css-tree@2.2.1:
+  css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
-    dependencies:
-      mdn-data: 2.0.28
-      source-map-js: 1.2.1
-    dev: true
 
-  /css-tree@2.3.1:
-    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-    dependencies:
-      mdn-data: 2.0.30
-      source-map-js: 1.2.1
-    dev: true
 
-  /css-what@6.1.0:
-    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
-    dev: true
 
-  /cssesc@3.0.0:
+  cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
-  /cssnano-preset-default@7.0.6(postcss@8.4.49):
-    resolution: {integrity: sha512-ZzrgYupYxEvdGGuqL+JKOY70s7+saoNlHSCK/OGn1vB2pQK8KSET8jvenzItcY+kA7NoWvfbb/YhlzuzNKjOhQ==}
+  cssnano-preset-default@7.0.13:
+    resolution: {integrity: sha512-/XvjNeb+oitOT9ks3Tg0UAsnXeHR1dh3wBMK/D/zN8gqvAHOp25FZGiLoQbvBBU203WXVNITkaqyFp4O/Rns4w==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      css-declaration-sorter: 7.2.0(postcss@8.4.49)
-      cssnano-utils: 5.0.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-calc: 10.0.2(postcss@8.4.49)
-      postcss-colormin: 7.0.2(postcss@8.4.49)
-      postcss-convert-values: 7.0.4(postcss@8.4.49)
-      postcss-discard-comments: 7.0.3(postcss@8.4.49)
-      postcss-discard-duplicates: 7.0.1(postcss@8.4.49)
-      postcss-discard-empty: 7.0.0(postcss@8.4.49)
-      postcss-discard-overridden: 7.0.0(postcss@8.4.49)
-      postcss-merge-longhand: 7.0.4(postcss@8.4.49)
-      postcss-merge-rules: 7.0.4(postcss@8.4.49)
-      postcss-minify-font-values: 7.0.0(postcss@8.4.49)
-      postcss-minify-gradients: 7.0.0(postcss@8.4.49)
-      postcss-minify-params: 7.0.2(postcss@8.4.49)
-      postcss-minify-selectors: 7.0.4(postcss@8.4.49)
-      postcss-normalize-charset: 7.0.0(postcss@8.4.49)
-      postcss-normalize-display-values: 7.0.0(postcss@8.4.49)
-      postcss-normalize-positions: 7.0.0(postcss@8.4.49)
-      postcss-normalize-repeat-style: 7.0.0(postcss@8.4.49)
-      postcss-normalize-string: 7.0.0(postcss@8.4.49)
-      postcss-normalize-timing-functions: 7.0.0(postcss@8.4.49)
-      postcss-normalize-unicode: 7.0.2(postcss@8.4.49)
-      postcss-normalize-url: 7.0.0(postcss@8.4.49)
-      postcss-normalize-whitespace: 7.0.0(postcss@8.4.49)
-      postcss-ordered-values: 7.0.1(postcss@8.4.49)
-      postcss-reduce-initial: 7.0.2(postcss@8.4.49)
-      postcss-reduce-transforms: 7.0.0(postcss@8.4.49)
-      postcss-svgo: 7.0.1(postcss@8.4.49)
-      postcss-unique-selectors: 7.0.3(postcss@8.4.49)
-    dev: true
+      postcss: ^8.4.32
 
-  /cssnano-utils@5.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-Uij0Xdxc24L6SirFr25MlwC2rCFX6scyUmuKpzI+JQ7cyqDEwD42fJ0xfB3yLfOnRDU5LKGgjQ9FA6LYh76GWQ==}
+  cssnano-utils@5.0.1:
+    resolution: {integrity: sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /cssnano@7.0.6(postcss@8.4.49):
-    resolution: {integrity: sha512-54woqx8SCbp8HwvNZYn68ZFAepuouZW4lTwiMVnBErM3VkO7/Sd4oTOt3Zz3bPx3kxQ36aISppyXj2Md4lg8bw==}
+  cssnano@7.1.5:
+    resolution: {integrity: sha512-4yEvjF2zcoAOWfNq6X687ORJc5SvM5xbg6EGuLSBmGoWZbsL69wpmw1tA3fZt7OwIG+G4ndjF95RSS4luvim7A==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      cssnano-preset-default: 7.0.6(postcss@8.4.49)
-      lilconfig: 3.1.3
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /csso@5.0.5:
+  csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
-    dependencies:
-      css-tree: 2.2.1
-    dev: true
 
-  /deepmerge@4.3.1:
+  deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  /default-browser-id@5.0.0:
-    resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
-    dev: true
 
-  /default-browser@5.2.1:
-    resolution: {integrity: sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==}
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
-    dependencies:
-      bundle-name: 4.1.0
-      default-browser-id: 5.0.0
-    dev: true
 
-  /define-lazy-prop@3.0.0:
+  define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
-    dev: true
 
-  /defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  /destr@2.0.3:
-    resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
-    dev: true
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
-  /dom-serializer@2.0.0:
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
-    dev: true
 
-  /domelementtype@2.3.0:
+  domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-    dev: true
 
-  /domhandler@5.0.3:
+  domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-    dependencies:
-      domelementtype: 2.3.0
-    dev: true
 
-  /domutils@3.1.0:
-    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-    dev: true
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
-  /dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
-    dev: true
 
-  /electron-to-chromium@1.5.73:
-    resolution: {integrity: sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==}
-    dev: true
+  electron-to-chromium@1.5.336:
+    resolution: {integrity: sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==}
 
-  /entities@4.5.0:
+  entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-    dev: true
 
-  /esbuild@0.24.2:
-    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.2
-      '@esbuild/android-arm': 0.24.2
-      '@esbuild/android-arm64': 0.24.2
-      '@esbuild/android-x64': 0.24.2
-      '@esbuild/darwin-arm64': 0.24.2
-      '@esbuild/darwin-x64': 0.24.2
-      '@esbuild/freebsd-arm64': 0.24.2
-      '@esbuild/freebsd-x64': 0.24.2
-      '@esbuild/linux-arm': 0.24.2
-      '@esbuild/linux-arm64': 0.24.2
-      '@esbuild/linux-ia32': 0.24.2
-      '@esbuild/linux-loong64': 0.24.2
-      '@esbuild/linux-mips64el': 0.24.2
-      '@esbuild/linux-ppc64': 0.24.2
-      '@esbuild/linux-riscv64': 0.24.2
-      '@esbuild/linux-s390x': 0.24.2
-      '@esbuild/linux-x64': 0.24.2
-      '@esbuild/netbsd-arm64': 0.24.2
-      '@esbuild/netbsd-x64': 0.24.2
-      '@esbuild/openbsd-arm64': 0.24.2
-      '@esbuild/openbsd-x64': 0.24.2
-      '@esbuild/sunos-x64': 0.24.2
-      '@esbuild/win32-arm64': 0.24.2
-      '@esbuild/win32-ia32': 0.24.2
-      '@esbuild/win32-x64': 0.24.2
-    dev: true
 
-  /esbuild@0.25.0:
-    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.0
-      '@esbuild/android-arm': 0.25.0
-      '@esbuild/android-arm64': 0.25.0
-      '@esbuild/android-x64': 0.25.0
-      '@esbuild/darwin-arm64': 0.25.0
-      '@esbuild/darwin-x64': 0.25.0
-      '@esbuild/freebsd-arm64': 0.25.0
-      '@esbuild/freebsd-x64': 0.25.0
-      '@esbuild/linux-arm': 0.25.0
-      '@esbuild/linux-arm64': 0.25.0
-      '@esbuild/linux-ia32': 0.25.0
-      '@esbuild/linux-loong64': 0.25.0
-      '@esbuild/linux-mips64el': 0.25.0
-      '@esbuild/linux-ppc64': 0.25.0
-      '@esbuild/linux-riscv64': 0.25.0
-      '@esbuild/linux-s390x': 0.25.0
-      '@esbuild/linux-x64': 0.25.0
-      '@esbuild/netbsd-arm64': 0.25.0
-      '@esbuild/netbsd-x64': 0.25.0
-      '@esbuild/openbsd-arm64': 0.25.0
-      '@esbuild/openbsd-x64': 0.25.0
-      '@esbuild/sunos-x64': 0.25.0
-      '@esbuild/win32-arm64': 0.25.0
-      '@esbuild/win32-ia32': 0.25.0
-      '@esbuild/win32-x64': 0.25.0
-    dev: true
-
-  /escalade@3.2.0:
+  escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-    dev: true
 
-  /estree-walker@2.0.2:
+  estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
-  /exsolve@1.0.7:
-    resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
-    dev: true
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  /fdir@6.4.2(picomatch@4.0.2):
-    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
-    dependencies:
-      picomatch: 4.0.2
-    dev: true
 
-  /fdir@6.4.3(picomatch@4.0.2):
-    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-    dependencies:
-      picomatch: 4.0.2
-    dev: true
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
-  /fix-dts-default-cjs-exports@1.0.0:
-    resolution: {integrity: sha512-i9Vd++WOWo6JilNgZvNvmy1T0r+/j7vikghQSEhKIuDwz4GjUrYj+Z18zlL7MleYNxE+xE6t3aG7LiAwA1P+dg==}
-    dependencies:
-      magic-string: 0.30.17
-      mlly: 1.7.4
-      rollup: 4.34.8
-    dev: true
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  /fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-    dev: true
-
-  /fsevents@2.3.3:
+  fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /function-bind@1.1.2:
+  function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
-  /giget@2.0.0:
-    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+  giget@3.2.0:
+    resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
     hasBin: true
-    dependencies:
-      citty: 0.1.6
-      consola: 3.4.2
-      defu: 6.1.4
-      node-fetch-native: 1.6.6
-      nypm: 0.6.0
-      pathe: 2.0.3
 
-  /hasown@2.0.2:
+  hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-    dependencies:
-      function-bind: 1.1.2
-    dev: true
 
-  /hookable@5.5.3:
+  hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
-    dev: true
 
-  /ini@5.0.0:
-    resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    dev: false
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  /is-core-module@2.13.1:
-    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
-    dependencies:
-      hasown: 2.0.2
-    dev: true
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
-  /is-docker@3.0.0:
+  is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-    dev: true
 
-  /is-inside-container@1.0.0:
+  is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
-    dependencies:
-      is-docker: 3.0.0
-    dev: true
 
-  /is-module@1.0.0:
+  is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
-    dev: true
 
-  /is-reference@1.2.1:
+  is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
-    dependencies:
-      '@types/estree': 1.0.6
-    dev: true
 
-  /is-wsl@3.1.0:
-    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
-    dependencies:
-      is-inside-container: 1.0.0
-    dev: true
 
-  /jiti@1.21.7:
+  jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
-    dev: true
 
-  /jiti@2.4.2:
-    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-    dev: true
 
-  /js-tokens@4.0.0:
+  js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /knitwork@1.2.0:
-    resolution: {integrity: sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==}
-    dev: true
+  knitwork@1.3.0:
+    resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
 
-  /lilconfig@3.1.3:
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
-    dev: true
 
-  /lodash.memoize@4.1.2:
+  lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
-    dev: true
 
-  /lodash.uniq@4.5.0:
+  lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
-    dev: true
 
-  /magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
-    dev: true
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  /mdn-data@2.0.28:
+  mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
-    dev: true
 
-  /mdn-data@2.0.30:
-    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
-    dev: true
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  /mkdist@2.2.0(typescript@5.8.3):
-    resolution: {integrity: sha512-GfKwu4A2grXfhj2TZm4ydfzP515NaALqKaPq4WqaZ6NhEnD47BiIQPySoCTTvVqHxYcuqVkNdCXjYf9Bz1Y04Q==}
+  mkdist@2.4.1:
+    resolution: {integrity: sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==}
     hasBin: true
     peerDependencies:
-      sass: ^1.83.0
-      typescript: '>=5.7.2'
-      vue: ^3.5.13
-      vue-tsc: ^1.8.27 || ^2.0.21
+      sass: ^1.92.1
+      typescript: '>=5.9.2'
+      vue: ^3.5.21
+      vue-sfc-transformer: ^0.1.1
+      vue-tsc: ^1.8.27 || ^2.0.21 || ^3.0.0
     peerDependenciesMeta:
       sass:
         optional: true
@@ -1354,681 +972,1692 @@ packages:
         optional: true
       vue:
         optional: true
+      vue-sfc-transformer:
+        optional: true
       vue-tsc:
         optional: true
-    dependencies:
-      autoprefixer: 10.4.20(postcss@8.4.49)
-      citty: 0.1.6
-      cssnano: 7.0.6(postcss@8.4.49)
-      defu: 6.1.4
-      esbuild: 0.24.2
-      jiti: 1.21.7
-      mlly: 1.7.4
-      pathe: 1.1.2
-      pkg-types: 1.3.1
-      postcss: 8.4.49
-      postcss-nested: 7.0.2(postcss@8.4.49)
-      semver: 7.7.1
-      tinyglobby: 0.2.12
-      typescript: 5.8.3
-    dev: true
 
-  /mlly@1.7.4:
-    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
-    dependencies:
-      acorn: 8.14.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.5.4
-    dev: true
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  /mri@1.2.0:
+  mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-    dev: true
 
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
-  /node-fetch-native@1.6.6:
-    resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
-  /node-releases@2.0.19:
-    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
-    dev: true
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
-  /normalize-range@0.1.2:
-    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  /nth-check@2.1.1:
+  nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-    dependencies:
-      boolbase: 1.0.0
-    dev: true
 
-  /nypm@0.6.0:
-    resolution: {integrity: sha512-mn8wBFV9G9+UFHIrq+pZ2r2zL4aPau/by3kJb3cM7+5tQHMt6HGQB8FDIeKFYp8o0D2pnH6nVsO88N4AmUxIWg==}
-    engines: {node: ^14.16.0 || >=16.10.0}
-    hasBin: true
-    dependencies:
-      citty: 0.1.6
-      consola: 3.4.2
-      pathe: 2.0.3
-      pkg-types: 2.0.0
-      tinyexec: 0.3.2
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  /ofetch@1.4.1:
-    resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
-    dependencies:
-      destr: 2.0.3
-      node-fetch-native: 1.6.6
-      ufo: 1.5.4
-    dev: true
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
-  /ohash@2.0.11:
+  ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
-    dev: true
 
-  /open@10.1.2:
-    resolution: {integrity: sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==}
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
-    dependencies:
-      default-browser: 5.2.1
-      define-lazy-prop: 3.0.0
-      is-inside-container: 1.0.0
-      is-wsl: 3.1.0
-    dev: true
 
-  /path-parse@1.0.7:
+  path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
-  /pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-    dev: true
-
-  /pathe@2.0.3:
+  pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  /perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
-    dev: true
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
-  /picocolors@1.1.1:
+  picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-    dev: true
 
-  /picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-    dev: true
 
-  /pkg-types@1.3.1:
+  pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.7.4
-      pathe: 2.0.3
-    dev: true
 
-  /pkg-types@2.0.0:
-    resolution: {integrity: sha512-W+831FxieJW1CIAh3JMmHaMhK/SiSeyCqbSWqLjjvbjaPDDY0cRkspIfOx4vLkFNgfxnzSxxGFUiMHMm6QpvYA==}
-    dependencies:
-      confbox: 0.1.8
-      pathe: 2.0.3
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  /pkg-types@2.2.0:
-    resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
-    dependencies:
-      confbox: 0.2.2
-      exsolve: 1.0.7
-      pathe: 2.0.3
-    dev: true
-
-  /postcss-calc@10.0.2(postcss@8.4.49):
-    resolution: {integrity: sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==}
+  postcss-calc@10.1.1:
+    resolution: {integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==}
     engines: {node: ^18.12 || ^20.9 || >=22.0}
     peerDependencies:
       postcss: ^8.4.38
-    dependencies:
-      postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-      postcss-value-parser: 4.2.0
-    dev: true
 
-  /postcss-colormin@7.0.2(postcss@8.4.49):
-    resolution: {integrity: sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==}
+  postcss-colormin@7.0.8:
+    resolution: {integrity: sha512-VX0JOZx0jECwGK0GZejIKvXIU+80S1zkjet31FVUYPZ4O+IPU3ZlntrPdPKT2HnKRMOkc0wy3m/v+c4UNta02g==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      caniuse-api: 3.0.0
-      colord: 2.9.3
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-convert-values@7.0.4(postcss@8.4.49):
-    resolution: {integrity: sha512-e2LSXPqEHVW6aoGbjV9RsSSNDO3A0rZLCBxN24zvxF25WknMPpX8Dm9UxxThyEbaytzggRuZxaGXqaOhxQ514Q==}
+  postcss-convert-values@7.0.10:
+    resolution: {integrity: sha512-hVqVH3cDkPyxL4Q0xpCquRAXjJDZ6hbpjC+PNWn8ZgHmNX3RZxLtruC3U2LY9EuNe+tp4QkcsZxg0htokmjydg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-discard-comments@7.0.3(postcss@8.4.49):
-    resolution: {integrity: sha512-q6fjd4WU4afNhWOA2WltHgCbkRhZPgQe7cXF74fuVB/ge4QbM9HEaOIzGSiMvM+g/cOsNAUGdf2JDzqA2F8iLA==}
+  postcss-discard-comments@7.0.6:
+    resolution: {integrity: sha512-Sq+Fzj1Eg5/CPf1ERb0wS1Im5cvE2gDXCE+si4HCn1sf+jpQZxDI4DXEp8t77B/ImzDceWE2ebJQFXdqZ6GRJw==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-discard-duplicates@7.0.1(postcss@8.4.49):
-    resolution: {integrity: sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==}
+  postcss-discard-duplicates@7.0.2:
+    resolution: {integrity: sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-discard-empty@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-e+QzoReTZ8IAwhnSdp/++7gBZ/F+nBq9y6PomfwORfP7q9nBpK5AMP64kOt0bA+lShBFbBDcgpJ3X4etHg4lzA==}
+  postcss-discard-empty@7.0.1:
+    resolution: {integrity: sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-discard-overridden@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-GmNAzx88u3k2+sBTZrJSDauR0ccpE24omTQCVmaTTZFz1du6AasspjaUPMJ2ud4RslZpoFKyf+6MSPETLojc6w==}
+  postcss-discard-overridden@7.0.1:
+    resolution: {integrity: sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-merge-longhand@7.0.4(postcss@8.4.49):
-    resolution: {integrity: sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==}
+  postcss-merge-longhand@7.0.5:
+    resolution: {integrity: sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-      stylehacks: 7.0.4(postcss@8.4.49)
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-merge-rules@7.0.4(postcss@8.4.49):
-    resolution: {integrity: sha512-ZsaamiMVu7uBYsIdGtKJ64PkcQt6Pcpep/uO90EpLS3dxJi6OXamIobTYcImyXGoW0Wpugh7DSD3XzxZS9JCPg==}
+  postcss-merge-rules@7.0.9:
+    resolution: {integrity: sha512-XKMXkHAegyLeIymVylg1Ro4NNHITInHPvmvybsIUximYfsg5fRw2b5TeqLTQwwg5cXEDVa556AAxvMve1MJuJA==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      caniuse-api: 3.0.0
-      cssnano-utils: 5.0.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-minify-font-values@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-2ckkZtgT0zG8SMc5aoNwtm5234eUx1GGFJKf2b1bSp8UflqaeFzR50lid4PfqVI9NtGqJ2J4Y7fwvnP/u1cQog==}
+  postcss-minify-font-values@7.0.1:
+    resolution: {integrity: sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-minify-gradients@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-pdUIIdj/C93ryCHew0UgBnL2DtUS3hfFa5XtERrs4x+hmpMYGhbzo6l/Ir5de41O0GaKVpK1ZbDNXSY6GkXvtg==}
+  postcss-minify-gradients@7.0.3:
+    resolution: {integrity: sha512-2znRFq3Pg+Zo0ttzQxO7qIJdY2er1TOZbclHW2qMqBcHMmz+i6nn3roAyG3kuEDQTzbzd3gn24TAIifEfth1PQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      colord: 2.9.3
-      cssnano-utils: 5.0.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-minify-params@7.0.2(postcss@8.4.49):
-    resolution: {integrity: sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==}
+  postcss-minify-params@7.0.7:
+    resolution: {integrity: sha512-OPmvW/9sjPEPQYnS2Sh6jvMW54wqk1IjjEMB8k/7V8SUIie71yMy3HQ9+w/ZHoL1YvgDGBQ/mCxP3n0Y/RxgqA==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      cssnano-utils: 5.0.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-minify-selectors@7.0.4(postcss@8.4.49):
-    resolution: {integrity: sha512-JG55VADcNb4xFCf75hXkzc1rNeURhlo7ugf6JjiiKRfMsKlDzN9CXHZDyiG6x/zGchpjQS+UAgb1d4nqXqOpmA==}
+  postcss-minify-selectors@7.0.6:
+    resolution: {integrity: sha512-lIbC0jy3AAwDxEgciZlBullDiMBeBCT+fz5G8RcA9MWqh/hfUkpOI3vNDUNEZHgokaoiv0juB9Y8fGcON7rU/A==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      cssesc: 3.0.0
-      postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-nested@7.0.2(postcss@8.4.49):
+  postcss-nested@7.0.2:
     resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       postcss: ^8.2.14
-    dependencies:
-      postcss: 8.4.49
-      postcss-selector-parser: 7.0.0
-    dev: true
 
-  /postcss-normalize-charset@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ==}
+  postcss-normalize-charset@7.0.1:
+    resolution: {integrity: sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-display-values@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-lnFZzNPeDf5uGMPYgGOw7v0BfB45+irSRz9gHQStdkkhiM0gTfvWkWB5BMxpn0OqgOQuZG/mRlZyJxp0EImr2Q==}
+  postcss-normalize-display-values@7.0.1:
+    resolution: {integrity: sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-positions@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-I0yt8wX529UKIGs2y/9Ybs2CelSvItfmvg/DBIjTnoUSrPxSV7Z0yZ8ShSVtKNaV/wAY+m7bgtyVQLhB00A1NQ==}
+  postcss-normalize-positions@7.0.1:
+    resolution: {integrity: sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-repeat-style@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-o3uSGYH+2q30ieM3ppu9GTjSXIzOrRdCUn8UOMGNw7Af61bmurHTWI87hRybrP6xDHvOe5WlAj3XzN6vEO8jLw==}
+  postcss-normalize-repeat-style@7.0.1:
+    resolution: {integrity: sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-string@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-w/qzL212DFVOpMy3UGyxrND+Kb0fvCiBBujiaONIihq7VvtC7bswjWgKQU/w4VcRyDD8gpfqUiBQ4DUOwEJ6Qg==}
+  postcss-normalize-string@7.0.1:
+    resolution: {integrity: sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-timing-functions@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-tNgw3YV0LYoRwg43N3lTe3AEWZ66W7Dh7lVEpJbHoKOuHc1sLrzMLMFjP8SNULHaykzsonUEDbKedv8C+7ej6g==}
+  postcss-normalize-timing-functions@7.0.1:
+    resolution: {integrity: sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-unicode@7.0.2(postcss@8.4.49):
-    resolution: {integrity: sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==}
+  postcss-normalize-unicode@7.0.7:
+    resolution: {integrity: sha512-Kfm0mC3gTnOC+SsLgxQqNEZStRxJgBaYrMpBe9fDVB0/MjC1G++FAeDW2YxYc5Mbvav12/7mOBSOTW7HK9Knwg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-url@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-+d7+PpE+jyPX1hDQZYG+NaFD+Nd2ris6r8fPTBAjE8z/U41n/bib3vze8x7rKs5H1uEw5ppe9IojewouHk0klQ==}
+  postcss-normalize-url@7.0.1:
+    resolution: {integrity: sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-normalize-whitespace@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-37/toN4wwZErqohedXYqWgvcHUGlT8O/m2jVkAfAe9Bd4MzRqlBmXrJRePH0e9Wgnz2X7KymTgTOaaFizQe3AQ==}
+  postcss-normalize-whitespace@7.0.1:
+    resolution: {integrity: sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-ordered-values@7.0.1(postcss@8.4.49):
-    resolution: {integrity: sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==}
+  postcss-ordered-values@7.0.2:
+    resolution: {integrity: sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      cssnano-utils: 5.0.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-reduce-initial@7.0.2(postcss@8.4.49):
-    resolution: {integrity: sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==}
+  postcss-reduce-initial@7.0.7:
+    resolution: {integrity: sha512-evetDQPqkgrzHoP8g3HjE3KgH0j2W0je2Vt1pfTaO2KvmjulStxGC2IGeI2y0pdLi6ryEGc4nD08zpDRP9ge8w==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      caniuse-api: 3.0.0
-      postcss: 8.4.49
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-reduce-transforms@7.0.0(postcss@8.4.49):
-    resolution: {integrity: sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew==}
+  postcss-reduce-transforms@7.0.1:
+    resolution: {integrity: sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-    dev: true
 
-  /postcss-selector-parser@7.0.0:
-    resolution: {integrity: sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-    dev: true
-
-  /postcss-svgo@7.0.1(postcss@8.4.49):
-    resolution: {integrity: sha512-0WBUlSL4lhD9rA5k1e5D8EN5wCEyZD6HJk0jIvRxl+FDVOMlJ7DePHYWGGVc5QRqrJ3/06FTXM0bxjmJpmTPSA==}
+  postcss-svgo@7.1.1:
+    resolution: {integrity: sha512-zU9H9oEDrUFKa0JB7w+IYL7Qs9ey1mZyjhbf0KLxwJDdDRtoPvCmaEfknzqfHj44QS9VD6c5sJnBAVYTLRg/Sg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >= 18}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-      svgo: 3.3.2
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-unique-selectors@7.0.3(postcss@8.4.49):
-    resolution: {integrity: sha512-J+58u5Ic5T1QjP/LDV9g3Cx4CNOgB5vz+kM6+OxHHhFACdcDeKhBXjQmB7fnIZM12YSTvsL0Opwco83DmacW2g==}
+  postcss-unique-selectors@7.0.5:
+    resolution: {integrity: sha512-3QoYmEt4qg/rUWDn6Tc8+ZVPmbp4G1hXDtCNWDx0st8SjtCbRcxRXDDM1QrEiXGG3A45zscSJFb4QH90LViyxg==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-    dev: true
+      postcss: ^8.4.32
 
-  /postcss-value-parser@4.2.0:
+  postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-    dev: true
 
-  /postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    dev: true
 
-  /pretty-bytes@6.1.1:
-    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-    dev: true
+  pretty-bytes@7.1.0:
+    resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
+    engines: {node: '>=20'}
 
-  /rc9@2.1.2:
-    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
-    dependencies:
-      defu: 6.1.4
-      destr: 2.0.3
-    dev: true
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
-  /readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
-    dev: true
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
-  /resolve@1.22.8:
-    resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
     hasBin: true
-    dependencies:
-      is-core-module: 2.13.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
-  /rollup-plugin-dts@6.1.1(rollup@4.34.8)(typescript@5.8.3):
-    resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
-    engines: {node: '>=16'}
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup-plugin-dts@6.4.1:
+    resolution: {integrity: sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==}
+    engines: {node: '>=20'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
-    dependencies:
-      magic-string: 0.30.17
-      rollup: 4.34.8
-      typescript: 5.8.3
-    optionalDependencies:
-      '@babel/code-frame': 7.26.2
-    dev: true
+      typescript: ^4.5 || ^5.0 || ^6.0
 
-  /rollup@4.34.8:
-    resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.34.8
-      '@rollup/rollup-android-arm64': 4.34.8
-      '@rollup/rollup-darwin-arm64': 4.34.8
-      '@rollup/rollup-darwin-x64': 4.34.8
-      '@rollup/rollup-freebsd-arm64': 4.34.8
-      '@rollup/rollup-freebsd-x64': 4.34.8
-      '@rollup/rollup-linux-arm-gnueabihf': 4.34.8
-      '@rollup/rollup-linux-arm-musleabihf': 4.34.8
-      '@rollup/rollup-linux-arm64-gnu': 4.34.8
-      '@rollup/rollup-linux-arm64-musl': 4.34.8
-      '@rollup/rollup-linux-loongarch64-gnu': 4.34.8
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.8
-      '@rollup/rollup-linux-riscv64-gnu': 4.34.8
-      '@rollup/rollup-linux-s390x-gnu': 4.34.8
-      '@rollup/rollup-linux-x64-gnu': 4.34.8
-      '@rollup/rollup-linux-x64-musl': 4.34.8
-      '@rollup/rollup-win32-arm64-msvc': 4.34.8
-      '@rollup/rollup-win32-ia32-msvc': 4.34.8
-      '@rollup/rollup-win32-x64-msvc': 4.34.8
-      fsevents: 2.3.3
-    dev: true
 
-  /run-applescript@7.0.0:
-    resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
-    dev: true
 
-  /scule@1.3.0:
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
+  scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
-    dev: true
 
-  /semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
-  /semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  /source-map-js@1.2.1:
+  source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  /std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
-    dev: true
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  /stylehacks@7.0.4(postcss@8.4.49):
-    resolution: {integrity: sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww==}
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  stylehacks@7.0.9:
+    resolution: {integrity: sha512-dgipCLBa16sZDoQ8BmXdRwV4SmFAxZ4KtbMhV0buow62M/2l6Jq6AkVsKUY/QFr8+VjgzXO5UVHx1f+vvY9DXw==}
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
-      postcss: ^8.4.31
-    dependencies:
-      browserslist: 4.24.3
-      postcss: 8.4.49
-      postcss-selector-parser: 6.1.2
-    dev: true
+      postcss: ^8.4.32
 
-  /supports-preserve-symlinks-flag@1.0.0:
+  supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
-  /svgo@3.3.2:
-    resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
-    engines: {node: '>=14.0.0'}
+  svgo@4.0.1:
+    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+    engines: {node: '>=16'}
     hasBin: true
-    dependencies:
-      '@trysound/sax': 0.2.0
-      commander: 7.2.0
-      css-select: 5.1.0
-      css-tree: 2.3.1
-      css-what: 6.1.0
-      csso: 5.0.5
-      picocolors: 1.1.1
-    dev: true
 
-  /tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  /tinyglobby@0.2.12:
-    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
-    dependencies:
-      fdir: 6.4.3(picomatch@4.0.2)
-      picomatch: 4.0.2
-    dev: true
 
-  /typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
-  /ufo@1.5.4:
-    resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
-    dev: true
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
-  /unbuild@3.5.0(typescript@5.8.3):
-    resolution: {integrity: sha512-DPFttsiADnHRb/K+yJ9r9jdn6JyXlsmdT0S12VFC14DFSJD+cxBnHq+v0INmqqPVPxOoUjvJFYUVIb02rWnVeA==}
+  unbuild@3.6.1:
+    resolution: {integrity: sha512-+U5CdtrdjfWkZhuO4N9l5UhyiccoeMEXIc2Lbs30Haxb+tRwB3VwB8AoZRxlAzORXunenSo+j6lh45jx+xkKgg==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.7.3
+      typescript: ^5.9.2
     peerDependenciesMeta:
       typescript:
         optional: true
-    dependencies:
-      '@rollup/plugin-alias': 5.1.1(rollup@4.34.8)
-      '@rollup/plugin-commonjs': 28.0.2(rollup@4.34.8)
-      '@rollup/plugin-json': 6.1.0(rollup@4.34.8)
-      '@rollup/plugin-node-resolve': 16.0.0(rollup@4.34.8)
-      '@rollup/plugin-replace': 6.0.2(rollup@4.34.8)
-      '@rollup/pluginutils': 5.1.4(rollup@4.34.8)
-      citty: 0.1.6
-      consola: 3.4.2
-      defu: 6.1.4
-      esbuild: 0.25.0
-      fix-dts-default-cjs-exports: 1.0.0
-      hookable: 5.5.3
-      jiti: 2.4.2
-      magic-string: 0.30.17
-      mkdist: 2.2.0(typescript@5.8.3)
-      mlly: 1.7.4
-      pathe: 2.0.3
-      pkg-types: 2.0.0
-      pretty-bytes: 6.1.1
-      rollup: 4.34.8
-      rollup-plugin-dts: 6.1.1(rollup@4.34.8)(typescript@5.8.3)
-      scule: 1.3.0
-      tinyglobby: 0.2.12
-      typescript: 5.8.3
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - sass
-      - vue
-      - vue-tsc
-    dev: true
 
-  /undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-    dev: true
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  /untyped@2.0.0:
+  untyped@2.0.0:
     resolution: {integrity: sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==}
     hasBin: true
-    dependencies:
-      citty: 0.1.6
-      defu: 6.1.4
-      jiti: 2.4.2
-      knitwork: 1.2.0
-      scule: 1.3.0
-    dev: true
 
-  /update-browserslist-db@1.1.1(browserslist@4.24.3):
-    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
     dependencies:
-      browserslist: 4.24.3
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+    optional: true
+
+  '@babel/helper-validator-identifier@7.28.5':
+    optional: true
+
+  '@colordx/core@5.0.3': {}
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.124.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
+
+  '@rollup/plugin-alias@5.1.1(rollup@4.60.1)':
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/plugin-commonjs@28.0.9(rollup@4.60.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/plugin-json@6.1.0(rollup@4.60.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.60.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.12
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/plugin-replace@6.0.3(rollup@4.60.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.1
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/ini@4.1.1': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/resolve@1.20.2': {}
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  acorn@8.16.0: {}
+
+  assertion-error@2.0.1: {}
+
+  autoprefixer@10.5.0(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001787
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  baseline-browser-mapping@2.10.18: {}
+
+  boolbase@1.0.0: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
+      electron-to-chromium: 1.5.336
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  c12@3.3.4:
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.0.8
+      giget: 3.2.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      rc9: 3.0.1
+
+  caniuse-api@3.0.0:
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001787
+      lodash.memoize: 4.1.2
+      lodash.uniq: 4.5.0
+
+  caniuse-lite@1.0.30001787: {}
+
+  chai@6.2.2: {}
+
+  changelogen@0.6.2:
+    dependencies:
+      c12: 3.3.4
+      confbox: 0.2.4
+      consola: 3.4.2
+      convert-gitmoji: 0.1.5
+      mri: 1.2.0
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      open: 10.2.0
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 3.10.0
+    transitivePeerDependencies:
+      - magicast
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  commander@11.1.0: {}
+
+  commondir@1.0.1: {}
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
+
+  convert-gitmoji@0.1.5: {}
+
+  convert-source-map@2.0.0: {}
+
+  css-declaration-sorter@7.4.0(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@2.2.1:
+    dependencies:
+      mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
+
+  cssesc@3.0.0: {}
+
+  cssnano-preset-default@7.0.13(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      css-declaration-sorter: 7.4.0(postcss@8.5.9)
+      cssnano-utils: 5.0.1(postcss@8.5.9)
+      postcss: 8.5.9
+      postcss-calc: 10.1.1(postcss@8.5.9)
+      postcss-colormin: 7.0.8(postcss@8.5.9)
+      postcss-convert-values: 7.0.10(postcss@8.5.9)
+      postcss-discard-comments: 7.0.6(postcss@8.5.9)
+      postcss-discard-duplicates: 7.0.2(postcss@8.5.9)
+      postcss-discard-empty: 7.0.1(postcss@8.5.9)
+      postcss-discard-overridden: 7.0.1(postcss@8.5.9)
+      postcss-merge-longhand: 7.0.5(postcss@8.5.9)
+      postcss-merge-rules: 7.0.9(postcss@8.5.9)
+      postcss-minify-font-values: 7.0.1(postcss@8.5.9)
+      postcss-minify-gradients: 7.0.3(postcss@8.5.9)
+      postcss-minify-params: 7.0.7(postcss@8.5.9)
+      postcss-minify-selectors: 7.0.6(postcss@8.5.9)
+      postcss-normalize-charset: 7.0.1(postcss@8.5.9)
+      postcss-normalize-display-values: 7.0.1(postcss@8.5.9)
+      postcss-normalize-positions: 7.0.1(postcss@8.5.9)
+      postcss-normalize-repeat-style: 7.0.1(postcss@8.5.9)
+      postcss-normalize-string: 7.0.1(postcss@8.5.9)
+      postcss-normalize-timing-functions: 7.0.1(postcss@8.5.9)
+      postcss-normalize-unicode: 7.0.7(postcss@8.5.9)
+      postcss-normalize-url: 7.0.1(postcss@8.5.9)
+      postcss-normalize-whitespace: 7.0.1(postcss@8.5.9)
+      postcss-ordered-values: 7.0.2(postcss@8.5.9)
+      postcss-reduce-initial: 7.0.7(postcss@8.5.9)
+      postcss-reduce-transforms: 7.0.1(postcss@8.5.9)
+      postcss-svgo: 7.1.1(postcss@8.5.9)
+      postcss-unique-selectors: 7.0.5(postcss@8.5.9)
+
+  cssnano-utils@5.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
+  cssnano@7.1.5(postcss@8.5.9):
+    dependencies:
+      cssnano-preset-default: 7.0.13(postcss@8.5.9)
+      lilconfig: 3.1.3
+      postcss: 8.5.9
+
+  csso@5.0.5:
+    dependencies:
+      css-tree: 2.2.1
+
+  deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  defu@6.1.7: {}
+
+  destr@2.0.5: {}
+
+  detect-libc@2.1.2: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dotenv@17.4.2: {}
+
+  electron-to-chromium@1.5.336: {}
+
+  entities@4.5.0: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  exsolve@1.0.8: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.1
+
+  fraction.js@5.3.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  giget@3.2.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hookable@5.5.3: {}
+
+  ini@6.0.0: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-docker@3.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-module@1.0.0: {}
+
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  jiti@1.21.7: {}
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0:
+    optional: true
+
+  knitwork@1.3.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lilconfig@3.1.3: {}
+
+  lodash.memoize@4.1.2: {}
+
+  lodash.uniq@4.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.0.28: {}
+
+  mdn-data@2.27.1: {}
+
+  mkdist@2.4.1(typescript@6.0.2):
+    dependencies:
+      autoprefixer: 10.5.0(postcss@8.5.9)
+      citty: 0.1.6
+      cssnano: 7.1.5(postcss@8.5.9)
+      defu: 6.1.7
+      esbuild: 0.25.12
+      jiti: 1.21.7
+      mlly: 1.8.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      postcss: 8.5.9
+      postcss-nested: 7.0.2(postcss@8.5.9)
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      typescript: 6.0.2
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  mri@1.2.0: {}
+
+  nanoid@3.3.11: {}
+
+  node-fetch-native@1.6.7: {}
+
+  node-releases@2.0.37: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  obug@2.1.1: {}
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.3
+
+  ohash@2.0.11: {}
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@2.1.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  postcss-calc@10.1.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+
+  postcss-colormin@7.0.8(postcss@8.5.9):
+    dependencies:
+      '@colordx/core': 5.0.3
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-convert-values@7.0.10(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-discard-comments@7.0.6(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+
+  postcss-discard-duplicates@7.0.2(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
+  postcss-discard-empty@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
+  postcss-discard-overridden@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
+  postcss-merge-longhand@7.0.5(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+      stylehacks: 7.0.9(postcss@8.5.9)
+
+  postcss-merge-rules@7.0.9(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      cssnano-utils: 5.0.1(postcss@8.5.9)
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+
+  postcss-minify-font-values@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-gradients@7.0.3(postcss@8.5.9):
+    dependencies:
+      '@colordx/core': 5.0.3
+      cssnano-utils: 5.0.1(postcss@8.5.9)
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-params@7.0.7(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      cssnano-utils: 5.0.1(postcss@8.5.9)
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-selectors@7.0.6(postcss@8.5.9):
+    dependencies:
+      cssesc: 3.0.0
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+
+  postcss-nested@7.0.2(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+
+  postcss-normalize-charset@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+
+  postcss-normalize-display-values@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-positions@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-repeat-style@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-string@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-timing-functions@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-unicode@7.0.7(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-url@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-ordered-values@7.0.2(postcss@8.5.9):
+    dependencies:
+      cssnano-utils: 5.0.1(postcss@8.5.9)
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-reduce-initial@7.0.7(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-api: 3.0.0
+      postcss: 8.5.9
+
+  postcss-reduce-transforms@7.0.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-svgo@7.1.1(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+      svgo: 4.0.1
+
+  postcss-unique-selectors@7.0.5(postcss@8.5.9):
+    dependencies:
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-bytes@7.1.0: {}
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  readdirp@5.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
+  rollup-plugin-dts@6.4.1(rollup@4.60.1)(typescript@6.0.2):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      convert-source-map: 2.0.0
+      magic-string: 0.30.21
+      rollup: 4.60.1
+      typescript: 6.0.2
+    optionalDependencies:
+      '@babel/code-frame': 7.29.0
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  run-applescript@7.1.0: {}
+
+  sax@1.6.0: {}
+
+  scule@1.3.0: {}
+
+  semver@7.7.4: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  std-env@4.0.0: {}
+
+  stylehacks@7.0.9(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      postcss: 8.5.9
+      postcss-selector-parser: 7.1.1
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  svgo@4.0.1:
+    dependencies:
+      commander: 11.1.0
+      css-select: 5.2.2
+      css-tree: 3.2.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.2: {}
+
+  ufo@1.6.3: {}
+
+  unbuild@3.6.1(typescript@6.0.2):
+    dependencies:
+      '@rollup/plugin-alias': 5.1.1(rollup@4.60.1)
+      '@rollup/plugin-commonjs': 28.0.9(rollup@4.60.1)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.1)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      esbuild: 0.25.12
+      fix-dts-default-cjs-exports: 1.0.1
+      hookable: 5.5.3
+      jiti: 2.6.1
+      magic-string: 0.30.21
+      mkdist: 2.4.1(typescript@6.0.2)
+      mlly: 1.8.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      pretty-bytes: 7.1.0
+      rollup: 4.60.1
+      rollup-plugin-dts: 6.4.1(rollup@4.60.1)(typescript@6.0.2)
+      scule: 1.3.0
+      tinyglobby: 0.2.16
+      untyped: 2.0.0
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - sass
+      - vue
+      - vue-sfc-transformer
+      - vue-tsc
+
+  undici-types@7.19.2: {}
+
+  untyped@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      defu: 6.1.7
+      jiti: 2.6.1
+      knitwork: 1.3.0
+      scule: 1.3.0
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-    dev: true
 
-  /util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
+  util-deprecate@1.0.2: {}
+
+  vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -51,6 +51,14 @@ export const resolveLogLevel = (value?: string): LogLevel | undefined => {
   )
 }
 
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
 export const registryArgs = {
   registryUrl: {
     type: 'string',

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -1,10 +1,76 @@
+import { LogLevels, type LogLevel } from 'consola'
+
+const namedLogLevels = {
+  silent: LogLevels.silent,
+  fatal: LogLevels.fatal,
+  error: LogLevels.error,
+  warn: LogLevels.warn,
+  log: LogLevels.log,
+  info: LogLevels.info,
+  debug: LogLevels.debug,
+  trace: LogLevels.trace,
+  verbose: LogLevels.verbose,
+} as const
+
+export const supportedLogLevels = Object.freeze(Object.keys(namedLogLevels))
+
 export const sharedArgs = {
   cwd: {
     type: 'string',
-    description: 'Current working directory',
+    description: 'Target directory, defaults to the directory where the command was invoked',
   },
   logLevel: {
     type: 'string',
-    description: 'Log level',
+    description: `Log level: ${supportedLogLevels.join(', ')} or a numeric level`,
+  },
+} as const
+
+export const resolveLogLevel = (value?: string): LogLevel | undefined => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const normalized = value.trim().toLowerCase()
+
+  if (!normalized) {
+    return undefined
+  }
+
+  if (/^\d+$/.test(normalized)) {
+    return Number(normalized) as LogLevel
+  }
+
+  const namedLevel = namedLogLevels[normalized as keyof typeof namedLogLevels]
+
+  if (namedLevel !== undefined) {
+    return namedLevel
+  }
+
+  throw new Error(
+    `invalid log level \"${value}\", expected one of ${supportedLogLevels.join(', ')} or a numeric level`,
+  )
+}
+
+export const registryArgs = {
+  registryUrl: {
+    type: 'string',
+    alias: 'r',
+    description: 'Direct template registry URL',
+  },
+  registryProvider: {
+    type: 'string',
+    description: 'Template registry provider: github, gitlab, gitee or url',
+  },
+  registryRepo: {
+    type: 'string',
+    description: 'Template registry repository path, for example xjccc-team/template-infos',
+  },
+  registryBranch: {
+    type: 'string',
+    description: 'Template registry branch or ref',
+  },
+  registryFile: {
+    type: 'string',
+    description: 'Template registry file path',
   },
 } as const

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -149,8 +149,16 @@ export default defineCommand({
       registryBranch: args.registryBranch,
       registryFile: args.registryFile,
     }
-    const registryConfig = resolveTemplateRegistryConfig(registryInput)
-    const hasRegistryOverride = hasTemplateRegistryOverride(registryInput)
+    let registryConfig: ReturnType<typeof resolveTemplateRegistryConfig>
+    let hasRegistryOverride: boolean
+
+    try {
+      registryConfig = resolveTemplateRegistryConfig(registryInput)
+      hasRegistryOverride = hasTemplateRegistryOverride(registryInput)
+    } catch (error) {
+      consola.error((error as Error).message)
+      process.exit(1)
+    }
 
     consola.start('get templates ...')
 
@@ -174,14 +182,19 @@ export default defineCommand({
     }
 
     if (!offline && (force || !cache || registryChanged || !cache.meta)) {
-      const data = await downloadTemplateInfo(registryConfig)
-      const meta = createTemplateCacheMeta(registryConfig)
+      try {
+        const data = await downloadTemplateInfo(registryConfig)
+        const meta = createTemplateCacheMeta(registryConfig)
 
-      await writeDefaultTemplateInfo(data, meta)
+        await writeDefaultTemplateInfo(data, meta)
 
-      cache = {
-        meta,
-        templates: data,
+        cache = {
+          meta,
+          templates: data,
+        }
+      } catch (error) {
+        consola.error((error as Error).message)
+        process.exit(1)
       }
     }
 
@@ -203,13 +216,18 @@ export default defineCommand({
     consola.start('start downloading ...')
 
     const dir = args.name || templateInfo?.defaultDir || template
-    await getTemplate({
-      offline,
-      dir,
-      template,
-      templateInfo,
-      cwd: projectPath
-    })
+    try {
+      await getTemplate({
+        offline,
+        dir,
+        template,
+        templateInfo,
+        cwd: projectPath
+      })
+    } catch (error) {
+      consola.error((error as Error).message)
+      process.exit(1)
+    }
 
     consola.success('create project successful!!')
     consola.box(`cd ${dir} && pnpm install`)

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -90,15 +90,6 @@ export default defineCommand({
     const projectPath = resolve(invocationCwd, args.cwd || '.')
     let template = args.template
     const directUrl = args.url?.trim()
-    const registryInput: TemplateRegistryArgs = {
-      registryUrl: args.registryUrl,
-      registryProvider: args.registryProvider,
-      registryRepo: args.registryRepo,
-      registryBranch: args.registryBranch,
-      registryFile: args.registryFile,
-    }
-    const registryConfig = resolveTemplateRegistryConfig(registryInput)
-    const hasRegistryOverride = hasTemplateRegistryOverride(registryInput)
 
     const force = args.force
     const offline = args.offline
@@ -150,6 +141,16 @@ export default defineCommand({
         process.exit(1)
       }
     }
+
+    const registryInput: TemplateRegistryArgs = {
+      registryUrl: args.registryUrl,
+      registryProvider: args.registryProvider,
+      registryRepo: args.registryRepo,
+      registryBranch: args.registryBranch,
+      registryFile: args.registryFile,
+    }
+    const registryConfig = resolveTemplateRegistryConfig(registryInput)
+    const hasRegistryOverride = hasTemplateRegistryOverride(registryInput)
 
     consola.start('get templates ...')
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty'
-import { registryArgs, resolveLogLevel, sharedArgs } from './_shared'
+import { getErrorMessage, registryArgs, resolveLogLevel, sharedArgs } from './_shared'
 import { consola } from 'consola'
 import { resolve } from 'pathe'
 import { createTemplateCacheMeta, hasTemplateRegistryOverride, resolveTemplateRegistryConfig } from '../registry'
@@ -13,7 +13,7 @@ import {
   resolveTemplateDirFromUrl,
   writeDefaultTemplateInfo,
 } from '../utils'
-import { TemplateRegistryArgs, TemplateOption } from '../types'
+import { TemplateCacheData, TemplateRegistryArgs, TemplateOption } from '../types'
 
 // const files: TemplateProvider = async (input, { auth }) => {
 //   return {
@@ -82,7 +82,7 @@ export default defineCommand({
         consola.level = logLevel
       }
     } catch (error) {
-      consola.error((error as Error).message)
+      consola.error(getErrorMessage(error))
       process.exit(1)
     }
 
@@ -99,13 +99,13 @@ export default defineCommand({
       process.exit(1)
     }
 
-    const hasExplicitRegistryArgs = Boolean(
-      args.registryUrl
-      || args.registryProvider
-      || args.registryRepo
-      || args.registryBranch
-      || args.registryFile,
-    )
+    const hasExplicitRegistryArgs = [
+      args.registryUrl,
+      args.registryProvider,
+      args.registryRepo,
+      args.registryBranch,
+      args.registryFile,
+    ].some(value => Boolean(value?.trim()))
 
     if (directUrl) {
       if (template) {
@@ -137,7 +137,7 @@ export default defineCommand({
         consola.box(`cd ${dir} && pnpm install`)
         return
       } catch (error) {
-        consola.error((error as Error).message)
+        consola.error(getErrorMessage(error))
         process.exit(1)
       }
     }
@@ -156,16 +156,23 @@ export default defineCommand({
       registryConfig = resolveTemplateRegistryConfig(registryInput)
       hasRegistryOverride = hasTemplateRegistryOverride(registryInput)
     } catch (error) {
-      consola.error((error as Error).message)
+      consola.error(getErrorMessage(error))
       process.exit(1)
     }
 
     consola.start('get templates ...')
 
     const hasJsonFile = await isFile(COPYJSON)
-    let cache = hasJsonFile
-      ? await readTemplateCache()
-      : undefined
+    let cache: TemplateCacheData | undefined
+
+    if (hasJsonFile) {
+      try {
+        cache = await readTemplateCache()
+      } catch (error) {
+        consola.error(getErrorMessage(error))
+        process.exit(1)
+      }
+    }
 
     if (offline && !cache) {
       consola.error('offline mode requires cached template info, run `c-copy update` first')
@@ -193,7 +200,7 @@ export default defineCommand({
           templates: data,
         }
       } catch (error) {
-        consola.error((error as Error).message)
+        consola.error(getErrorMessage(error))
         process.exit(1)
       }
     }
@@ -226,7 +233,7 @@ export default defineCommand({
         cwd: projectPath
       })
     } catch (error) {
-      consola.error((error as Error).message)
+      consola.error(getErrorMessage(error))
       process.exit(1)
     }
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -3,7 +3,7 @@ import { registryArgs, resolveLogLevel, sharedArgs } from './_shared'
 import { consola } from 'consola'
 import { resolve } from 'pathe'
 import { createTemplateCacheMeta, hasTemplateRegistryOverride, resolveTemplateRegistryConfig } from '../registry'
-import { COPYJSON, downloadTemplateInfo, getTemplate, isExist, readTemplateCache, writeDefaultTemplateInfo } from '../utils'
+import { COPYJSON, downloadTemplateInfo, getTemplate, isFile, readTemplateCache, writeDefaultTemplateInfo } from '../utils'
 import { TemplateRegistryArgs, TemplateOption } from '../types'
 
 // const files: TemplateProvider = async (input, { auth }) => {
@@ -75,15 +75,15 @@ export default defineCommand({
     const invocationCwd = process.env.INIT_CWD || process.env.PWD || process.cwd()
     const projectPath = resolve(invocationCwd, args.cwd || '.')
     let template = args.template
-    const registryArgs: TemplateRegistryArgs = {
+    const registryInput: TemplateRegistryArgs = {
       registryUrl: args.registryUrl,
       registryProvider: args.registryProvider,
       registryRepo: args.registryRepo,
       registryBranch: args.registryBranch,
       registryFile: args.registryFile,
     }
-    const registryConfig = resolveTemplateRegistryConfig(registryArgs)
-    const hasRegistryOverride = hasTemplateRegistryOverride(registryArgs)
+    const registryConfig = resolveTemplateRegistryConfig(registryInput)
+    const hasRegistryOverride = hasTemplateRegistryOverride(registryInput)
 
     const force = args.force
     const offline = args.offline
@@ -95,7 +95,7 @@ export default defineCommand({
 
     consola.start('get templates ...')
 
-    const hasJsonFile = await isExist(COPYJSON)
+    const hasJsonFile = await isFile(COPYJSON)
     let cache = hasJsonFile
       ? await readTemplateCache()
       : undefined

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,11 +1,10 @@
 import { defineCommand } from 'citty'
-import { sharedArgs } from './_shared'
+import { registryArgs, resolveLogLevel, sharedArgs } from './_shared'
 import { consola } from 'consola'
 import { resolve } from 'pathe'
-import { readFile } from 'node:fs/promises'
-import { isExist, __dirname, COPYJSON, getTemplate, downloadTemplateInfo, writeDefaultTemplateInfo } from '../utils'
-import ini from 'ini'
-import { SelectOption } from '../types'
+import { createTemplateCacheMeta, hasTemplateRegistryOverride, resolveTemplateRegistryConfig } from '../registry'
+import { COPYJSON, downloadTemplateInfo, getTemplate, isExist, readTemplateCache, writeDefaultTemplateInfo } from '../utils'
+import { TemplateRegistryArgs, TemplateOption } from '../types'
 
 // const files: TemplateProvider = async (input, { auth }) => {
 //   return {
@@ -16,6 +15,20 @@ import { SelectOption } from '../types'
 // };
 // const files = registryProvider("https://raw.githubusercontent.com/xjccc-team/main/template-infos")
 
+const selectTemplate = async (projectOptions: TemplateOption[]) => {
+  const template = await consola.prompt('select a template', {
+    type: 'select',
+    options: projectOptions
+  })
+
+  if (!template || typeof template !== 'string') {
+    consola.warn('template selection cancelled')
+    process.exit(1)
+  }
+
+  return template
+}
+
 export default defineCommand({
   meta: {
     name: 'create',
@@ -23,20 +36,21 @@ export default defineCommand({
   },
   args: {
     ...sharedArgs,
+    ...registryArgs,
     template: {
       type: 'string',
       alias: 't',
-      description: 'vue template name'
+      description: 'template name from registry'
     },
     force: {
       type: 'boolean',
-      description: 'update template json latest',
+      description: 'refresh template registry before create',
       alias: 'f',
       default: false
     },
     offline: {
       type: 'boolean',
-      description: 'force offline mode',
+      description: 'use cached registry and giget cache only',
       alias: 'o',
       default: false
     },
@@ -47,47 +61,94 @@ export default defineCommand({
     }
   },
   async run ({ args }) {
-    const projectPath = resolve(args.cwd || '.')
-    let template = args.template
+    try {
+      const logLevel = resolveLogLevel(args.logLevel)
 
-    consola.start('get templates ...')
+      if (logLevel !== undefined) {
+        consola.level = logLevel
+      }
+    } catch (error) {
+      consola.error((error as Error).message)
+      process.exit(1)
+    }
+
+    const invocationCwd = process.env.INIT_CWD || process.env.PWD || process.cwd()
+    const projectPath = resolve(invocationCwd, args.cwd || '.')
+    let template = args.template
+    const registryArgs: TemplateRegistryArgs = {
+      registryUrl: args.registryUrl,
+      registryProvider: args.registryProvider,
+      registryRepo: args.registryRepo,
+      registryBranch: args.registryBranch,
+      registryFile: args.registryFile,
+    }
+    const registryConfig = resolveTemplateRegistryConfig(registryArgs)
+    const hasRegistryOverride = hasTemplateRegistryOverride(registryArgs)
 
     const force = args.force
     const offline = args.offline
 
-    const hasJsonFile = await isExist(COPYJSON)
-
-    if (force || !hasJsonFile) {
-      const data = await downloadTemplateInfo()
-      await writeDefaultTemplateInfo(data)
+    if (force && offline) {
+      consola.error('--force and --offline cannot be used together')
+      process.exit(1)
     }
 
-    const data = ini.parse(
-      await readFile(COPYJSON, {
-        encoding: 'utf8'
-      })
-    )
+    consola.start('get templates ...')
 
-    const projectOptions: SelectOption[] = Object.keys(data).map(item => {
-      return data[item]
-    })
+    const hasJsonFile = await isExist(COPYJSON)
+    let cache = hasJsonFile
+      ? await readTemplateCache()
+      : undefined
+
+    if (offline && !cache) {
+      consola.error('offline mode requires cached template info, run `c-copy update` first')
+      process.exit(1)
+    }
+
+    const registryChanged = cache?.meta?.registryUrl
+      ? cache.meta.registryUrl !== registryConfig.resolvedUrl
+      : hasRegistryOverride
+
+    if (offline && registryChanged) {
+      consola.error('offline mode cannot use cache from another registry, run `c-copy update` first')
+      process.exit(1)
+    }
+
+    if (!offline && (force || !cache || registryChanged || !cache.meta)) {
+      const data = await downloadTemplateInfo(registryConfig)
+      const meta = createTemplateCacheMeta(registryConfig)
+
+      await writeDefaultTemplateInfo(data, meta)
+
+      cache = {
+        meta,
+        templates: data,
+      }
+    }
+
+    const data = cache?.templates || {}
+    const projectOptions = Object.values(data)
+
+    if (!projectOptions.length) {
+      consola.error('no templates available, run `c-copy update` first')
+      process.exit(1)
+    }
 
     const templateNames = projectOptions.map(item => item.value)
     if (!template || !templateNames.includes(template)) {
-      template = (await consola.prompt('select a template', {
-        type: 'select',
-        options: projectOptions
-      })) as unknown as string
+      template = await selectTemplate(projectOptions)
     }
+
+    const templateInfo = data[template]
 
     consola.start('start downloading ...')
 
-    const dir = args.name || template
+    const dir = args.name || templateInfo?.defaultDir || template
     await getTemplate({
-      force,
       offline,
       dir,
       template,
+      templateInfo,
       cwd: projectPath
     })
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -3,7 +3,16 @@ import { registryArgs, resolveLogLevel, sharedArgs } from './_shared'
 import { consola } from 'consola'
 import { resolve } from 'pathe'
 import { createTemplateCacheMeta, hasTemplateRegistryOverride, resolveTemplateRegistryConfig } from '../registry'
-import { COPYJSON, downloadTemplateInfo, getTemplate, isFile, readTemplateCache, writeDefaultTemplateInfo } from '../utils'
+import {
+  COPYJSON,
+  createTemplateInfoFromUrl,
+  downloadTemplateInfo,
+  getTemplate,
+  isFile,
+  readTemplateCache,
+  resolveTemplateDirFromUrl,
+  writeDefaultTemplateInfo,
+} from '../utils'
 import { TemplateRegistryArgs, TemplateOption } from '../types'
 
 // const files: TemplateProvider = async (input, { auth }) => {
@@ -37,6 +46,11 @@ export default defineCommand({
   args: {
     ...sharedArgs,
     ...registryArgs,
+    url: {
+      type: 'string',
+      alias: 'u',
+      description: 'Direct template URL to download, bypassing registry lookup',
+    },
     template: {
       type: 'string',
       alias: 't',
@@ -75,6 +89,7 @@ export default defineCommand({
     const invocationCwd = process.env.INIT_CWD || process.env.PWD || process.cwd()
     const projectPath = resolve(invocationCwd, args.cwd || '.')
     let template = args.template
+    const directUrl = args.url?.trim()
     const registryInput: TemplateRegistryArgs = {
       registryUrl: args.registryUrl,
       registryProvider: args.registryProvider,
@@ -91,6 +106,49 @@ export default defineCommand({
     if (force && offline) {
       consola.error('--force and --offline cannot be used together')
       process.exit(1)
+    }
+
+    const hasExplicitRegistryArgs = Boolean(
+      args.registryUrl
+      || args.registryProvider
+      || args.registryRepo
+      || args.registryBranch
+      || args.registryFile,
+    )
+
+    if (directUrl) {
+      if (template) {
+        consola.error('--template cannot be used together with --url')
+        process.exit(1)
+      }
+
+      if (hasExplicitRegistryArgs) {
+        consola.error('registry options cannot be used together with --url')
+        process.exit(1)
+      }
+
+      try {
+        const dir = args.name || resolveTemplateDirFromUrl(directUrl)
+        const templateInfo = createTemplateInfoFromUrl(directUrl, dir)
+
+        consola.start('start downloading ...')
+
+        await getTemplate({
+          cwd: projectPath,
+          dir,
+          force,
+          offline,
+          template: dir,
+          templateInfo,
+        })
+
+        consola.success('create project successful!!')
+        consola.box(`cd ${dir} && pnpm install`)
+        return
+      } catch (error) {
+        consola.error((error as Error).message)
+        process.exit(1)
+      }
     }
 
     consola.start('get templates ...')

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -218,6 +218,7 @@ export default defineCommand({
     const dir = args.name || templateInfo?.defaultDir || template
     try {
       await getTemplate({
+        force,
         offline,
         dir,
         template,

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,5 +1,4 @@
 import { downloadTemplate } from 'giget'
-import { consola } from 'consola'
 
 const getTemplate = async (dirName: string) => {
   const { source, dir } = await downloadTemplate(

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,15 +1,86 @@
-import { downloadTemplate } from 'giget'
+import { defineCommand } from 'citty'
+import { consola } from 'consola'
+import { resolve } from 'pathe'
+import { resolveLogLevel, sharedArgs } from './_shared'
+import { createTemplateInfoFromUrl, getTemplate, resolveTemplateDirFromUrl } from '../utils'
 
-const getTemplate = async (dirName: string) => {
-  const { source, dir } = await downloadTemplate(
-    'github:xjccc-team/vue2-template',
-    {
-      dir: dirName,
-      force: false
+export default defineCommand({
+  meta: {
+    name: 'download',
+    description: 'download template content directly from a URL'
+  },
+  args: {
+    ...sharedArgs,
+    url: {
+      type: 'string',
+      alias: 'u',
+      required: true,
+      description: 'Direct template URL to download',
+    },
+    force: {
+      type: 'boolean',
+      description: 'refresh template content before download',
+      alias: 'f',
+      default: false,
+    },
+    offline: {
+      type: 'boolean',
+      description: 'use giget cache only',
+      alias: 'o',
+      default: false,
+    },
+    name: {
+      type: 'positional',
+      required: false,
+      valueHint: 'name'
     }
-  )
+  },
+  async run ({ args }) {
+    try {
+      const logLevel = resolveLogLevel(args.logLevel)
 
-  console.log(source, dir)
-}
+      if (logLevel !== undefined) {
+        consola.level = logLevel
+      }
+    } catch (error) {
+      consola.error((error as Error).message)
+      process.exit(1)
+    }
 
-getTemplate('vue2-template')
+    if (args.force && args.offline) {
+      consola.error('--force and --offline cannot be used together')
+      process.exit(1)
+    }
+
+    const invocationCwd = process.env.INIT_CWD || process.env.PWD || process.cwd()
+    const projectPath = resolve(invocationCwd, args.cwd || '.')
+    const directUrl = args.url?.trim()
+
+    if (!directUrl) {
+      consola.error('--url is required')
+      process.exit(1)
+    }
+
+    try {
+      const dir = args.name || resolveTemplateDirFromUrl(directUrl)
+      const templateInfo = createTemplateInfoFromUrl(directUrl, dir)
+
+      consola.start('start downloading ...')
+
+      await getTemplate({
+        cwd: projectPath,
+        dir,
+        force: args.force,
+        offline: args.offline,
+        template: dir,
+        templateInfo,
+      })
+
+      consola.success('download template successful!!')
+      consola.box(`cd ${dir} && pnpm install`)
+    } catch (error) {
+      consola.error((error as Error).message)
+      process.exit(1)
+    }
+  }
+})

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 import { consola } from 'consola'
 import { resolve } from 'pathe'
-import { resolveLogLevel, sharedArgs } from './_shared'
+import { getErrorMessage, resolveLogLevel, sharedArgs } from './_shared'
 import { createTemplateInfoFromUrl, getTemplate, resolveTemplateDirFromUrl } from '../utils'
 
 export default defineCommand({
@@ -43,7 +43,7 @@ export default defineCommand({
         consola.level = logLevel
       }
     } catch (error) {
-      consola.error((error as Error).message)
+      consola.error(getErrorMessage(error))
       process.exit(1)
     }
 
@@ -79,7 +79,7 @@ export default defineCommand({
       consola.success('download template successful!!')
       consola.box(`cd ${dir} && pnpm install`)
     } catch (error) {
-      consola.error((error as Error).message)
+      consola.error(getErrorMessage(error))
       process.exit(1)
     }
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ const _rDefault = (r: any) => (r.default || r) as Promise<CommandDef>
 
 export const commands = {
   create: () => import('./create').then(_rDefault),
+  download: () => import('./download').then(_rDefault),
   show: () => import('./show').then(_rDefault),
   clean: () => import('./clean').then(_rDefault),
   update: () => import('./update').then(_rDefault)

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -12,7 +12,7 @@ export default defineCommand({
       const data = await readTemplateCache()
       consola.info(JSON.stringify(data, null, 2))
     } else {
-      consola.error("can't find .ccopyrc")
+      consola.error('.ccopyrc was not found or is not a file')
       process.exit(1)
     }
   }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 import consola from 'consola'
-import { COPYJSON, isExist, readTemplateCache } from '../utils'
+import { COPYJSON, isFile, readTemplateCache } from '../utils'
 
 export default defineCommand({
   meta: {
@@ -8,7 +8,7 @@ export default defineCommand({
     description: 'show .ccopyrc config'
   },
   async run () {
-    if (await isExist(COPYJSON)) {
+    if (await isFile(COPYJSON)) {
       const data = await readTemplateCache()
       consola.info(JSON.stringify(data, null, 2))
     } else {

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'citty'
 import consola from 'consola'
+import { getErrorMessage } from './_shared'
 import { COPYJSON, isFile, readTemplateCache } from '../utils'
 
 export default defineCommand({
@@ -9,8 +10,13 @@ export default defineCommand({
   },
   async run () {
     if (await isFile(COPYJSON)) {
-      const data = await readTemplateCache()
-      consola.info(JSON.stringify(data, null, 2))
+      try {
+        const data = await readTemplateCache()
+        consola.info(JSON.stringify(data, null, 2))
+      } catch (error) {
+        consola.error(getErrorMessage(error))
+        process.exit(1)
+      }
     } else {
       consola.error('.ccopyrc was not found or is not a file')
       process.exit(1)

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,8 +1,6 @@
 import { defineCommand } from 'citty'
 import consola from 'consola'
-import { readFile } from 'node:fs/promises'
-import { COPYJSON, isExist } from '../utils'
-import ini from 'ini'
+import { COPYJSON, isExist, readTemplateCache } from '../utils'
 
 export default defineCommand({
   meta: {
@@ -11,8 +9,8 @@ export default defineCommand({
   },
   async run () {
     if (await isExist(COPYJSON)) {
-      const json = await readFile(COPYJSON, { encoding: 'utf8' })
-      consola.info(JSON.stringify(ini.parse(json), null, 2))
+      const data = await readTemplateCache()
+      consola.info(JSON.stringify(data, null, 2))
     } else {
       consola.error("can't find .ccopyrc")
       process.exit(1)

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -14,14 +14,14 @@ export default defineCommand({
     ...registryArgs,
   },
   async run ({ args }) {
-    const registryArgs: TemplateRegistryArgs = {
+    const registryInput: TemplateRegistryArgs = {
       registryUrl: args.registryUrl,
       registryProvider: args.registryProvider,
       registryRepo: args.registryRepo,
       registryBranch: args.registryBranch,
       registryFile: args.registryFile,
     }
-    const registryConfig = resolveTemplateRegistryConfig(registryArgs)
+    const registryConfig = resolveTemplateRegistryConfig(registryInput)
 
     consola.start('updating ...')
     const data = await downloadTemplateInfo(registryConfig)

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -21,11 +21,17 @@ export default defineCommand({
       registryBranch: args.registryBranch,
       registryFile: args.registryFile,
     }
-    const registryConfig = resolveTemplateRegistryConfig(registryInput)
 
-    consola.start('updating ...')
-    const data = await downloadTemplateInfo(registryConfig)
-    await writeDefaultTemplateInfo(data, createTemplateCacheMeta(registryConfig))
-    consola.success('update success!!')
+    try {
+      const registryConfig = resolveTemplateRegistryConfig(registryInput)
+
+      consola.start('updating ...')
+      const data = await downloadTemplateInfo(registryConfig)
+      await writeDefaultTemplateInfo(data, createTemplateCacheMeta(registryConfig))
+      consola.success('update success!!')
+    } catch (error) {
+      consola.error((error as Error).message)
+      process.exit(1)
+    }
   }
 })

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 import { downloadTemplateInfo, writeDefaultTemplateInfo } from '../utils'
 import consola from 'consola'
-import { registryArgs } from './_shared'
+import { getErrorMessage, registryArgs } from './_shared'
 import { createTemplateCacheMeta, resolveTemplateRegistryConfig } from '../registry'
 import { TemplateRegistryArgs } from '../types'
 
@@ -30,7 +30,7 @@ export default defineCommand({
       await writeDefaultTemplateInfo(data, createTemplateCacheMeta(registryConfig))
       consola.success('update success!!')
     } catch (error) {
-      consola.error((error as Error).message)
+      consola.error(getErrorMessage(error))
       process.exit(1)
     }
   }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,16 +1,31 @@
 import { defineCommand } from 'citty'
 import { downloadTemplateInfo, writeDefaultTemplateInfo } from '../utils'
 import consola from 'consola'
+import { registryArgs } from './_shared'
+import { createTemplateCacheMeta, resolveTemplateRegistryConfig } from '../registry'
+import { TemplateRegistryArgs } from '../types'
 
 export default defineCommand({
   meta: {
     name: 'update',
     description: 'update .ccopyrc template info'
   },
-  async run () {
+  args: {
+    ...registryArgs,
+  },
+  async run ({ args }) {
+    const registryArgs: TemplateRegistryArgs = {
+      registryUrl: args.registryUrl,
+      registryProvider: args.registryProvider,
+      registryRepo: args.registryRepo,
+      registryBranch: args.registryBranch,
+      registryFile: args.registryFile,
+    }
+    const registryConfig = resolveTemplateRegistryConfig(registryArgs)
+
     consola.start('updating ...')
-    const data = await downloadTemplateInfo()
-    await writeDefaultTemplateInfo(data)
+    const data = await downloadTemplateInfo(registryConfig)
+    await writeDefaultTemplateInfo(data, createTemplateCacheMeta(registryConfig))
     consola.success('update success!!')
   }
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 import { commands } from './commands'
-import pkg from '../package.json' assert { type: 'json' }
+import pkg from '../package.json' with { type: 'json' }
 
 // import { checkForUpdates } from './utils/update'
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -34,6 +34,7 @@ const PROVIDER_ALIASES: Record<string, TemplateRegistryProvider> = {
 
 const trimPath = (value: string) => value.replace(/^\/+|\/+$/g, '')
 const trimFile = (value: string) => value.replace(/^\/+/, '')
+const hasMeaningfulString = (value?: string) => Boolean(value?.trim())
 
 export const normalizeTemplateRegistryProvider = (
   input?: string,
@@ -58,16 +59,16 @@ export const hasTemplateRegistryOverride = (
   env: NodeJS.ProcessEnv = process.env,
 ) => {
   return Boolean(
-    args.registryUrl
-    || args.registryProvider
-    || args.registryRepo
-    || args.registryBranch
-    || args.registryFile
-    || env[REGISTRY_ENV_KEYS.url]
-    || env[REGISTRY_ENV_KEYS.provider]
-    || env[REGISTRY_ENV_KEYS.repo]
-    || env[REGISTRY_ENV_KEYS.branch]
-    || env[REGISTRY_ENV_KEYS.file],
+    hasMeaningfulString(args.registryUrl)
+    || hasMeaningfulString(args.registryProvider)
+    || hasMeaningfulString(args.registryRepo)
+    || hasMeaningfulString(args.registryBranch)
+    || hasMeaningfulString(args.registryFile)
+    || hasMeaningfulString(env[REGISTRY_ENV_KEYS.url])
+    || hasMeaningfulString(env[REGISTRY_ENV_KEYS.provider])
+    || hasMeaningfulString(env[REGISTRY_ENV_KEYS.repo])
+    || hasMeaningfulString(env[REGISTRY_ENV_KEYS.branch])
+    || hasMeaningfulString(env[REGISTRY_ENV_KEYS.file]),
   )
 }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -71,6 +71,25 @@ export const hasTemplateRegistryOverride = (
   )
 }
 
+const normalizeRegistryUrl = (input: string) => {
+  let parsedUrl: URL
+
+  try {
+    parsedUrl = new URL(input)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`invalid registry url: ${input}. ${message}`)
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error(
+      `invalid registry url protocol: ${parsedUrl.protocol}. Only http: and https: are supported`,
+    )
+  }
+
+  return parsedUrl.toString()
+}
+
 export const buildTemplateRegistryUrl = (config: TemplateRegistryConfig) => {
   if (config.provider === 'url') {
     const input = config.url?.trim()
@@ -79,7 +98,7 @@ export const buildTemplateRegistryUrl = (config: TemplateRegistryConfig) => {
       throw new Error('registry url is required when provider is url')
     }
 
-    return new URL(input).toString()
+    return normalizeRegistryUrl(input)
   }
 
   const repo = trimPath(config.repo || '')

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,186 @@
+import {
+  ResolvedTemplateRegistryConfig,
+  TemplateCacheMeta,
+  TemplateRegistryArgs,
+  TemplateRegistryConfig,
+  TemplateRegistryProvider,
+} from './types'
+
+export const REGISTRY_ENV_KEYS = {
+  url: 'C_COPY_REGISTRY_URL',
+  provider: 'C_COPY_REGISTRY_PROVIDER',
+  repo: 'C_COPY_REGISTRY_REPO',
+  branch: 'C_COPY_REGISTRY_BRANCH',
+  file: 'C_COPY_REGISTRY_FILE',
+} as const
+
+export const DEFAULT_TEMPLATE_REGISTRY_CONFIG: TemplateRegistryConfig = {
+  provider: 'github',
+  repo: 'xjccc-team/template-infos',
+  branch: 'main',
+  file: 'templates.json',
+}
+
+const PROVIDER_ALIASES: Record<string, TemplateRegistryProvider> = {
+  github: 'github',
+  gh: 'github',
+  gitlab: 'gitlab',
+  gl: 'gitlab',
+  gitee: 'gitee',
+  ge: 'gitee',
+  url: 'url',
+  raw: 'url',
+}
+
+const trimPath = (value: string) => value.replace(/^\/+|\/+$/g, '')
+const trimFile = (value: string) => value.replace(/^\/+/, '')
+
+export const normalizeTemplateRegistryProvider = (
+  input?: string,
+): TemplateRegistryProvider => {
+  const normalized = input?.trim().toLowerCase()
+
+  if (!normalized) {
+    return DEFAULT_TEMPLATE_REGISTRY_CONFIG.provider
+  }
+
+  const provider = PROVIDER_ALIASES[normalized]
+
+  if (!provider) {
+    throw new Error(`Unsupported template registry provider: ${input}`)
+  }
+
+  return provider
+}
+
+export const hasTemplateRegistryOverride = (
+  args: TemplateRegistryArgs = {},
+  env: NodeJS.ProcessEnv = process.env,
+) => {
+  return Boolean(
+    args.registryUrl
+    || args.registryProvider
+    || args.registryRepo
+    || args.registryBranch
+    || args.registryFile
+    || env[REGISTRY_ENV_KEYS.url]
+    || env[REGISTRY_ENV_KEYS.provider]
+    || env[REGISTRY_ENV_KEYS.repo]
+    || env[REGISTRY_ENV_KEYS.branch]
+    || env[REGISTRY_ENV_KEYS.file],
+  )
+}
+
+export const buildTemplateRegistryUrl = (config: TemplateRegistryConfig) => {
+  if (config.provider === 'url') {
+    const input = config.url?.trim()
+
+    if (!input) {
+      throw new Error('registry url is required when provider is url')
+    }
+
+    return new URL(input).toString()
+  }
+
+  const repo = trimPath(config.repo || '')
+  const branch = trimPath(config.branch)
+  const file = trimFile(config.file)
+
+  if (!repo) {
+    throw new Error('registry repo is required')
+  }
+
+  if (!branch) {
+    throw new Error('registry branch is required')
+  }
+
+  if (!file) {
+    throw new Error('registry file is required')
+  }
+
+  if (config.provider === 'gitlab') {
+    return `https://gitlab.com/${repo}/-/raw/${branch}/${file}`
+  }
+
+  if (config.provider === 'gitee') {
+    return `https://gitee.com/${repo}/raw/${branch}/${file}`
+  }
+
+  return `https://raw.githubusercontent.com/${repo}/${branch}/${file}`
+}
+
+export const resolveTemplateRegistryConfig = (
+  args: TemplateRegistryArgs = {},
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedTemplateRegistryConfig => {
+  const directUrl = args.registryUrl?.trim() || env[REGISTRY_ENV_KEYS.url]?.trim()
+
+  if (directUrl) {
+    return {
+      provider: 'url',
+      url: directUrl,
+      repo: undefined,
+      branch: '',
+      file: '',
+      resolvedUrl: buildTemplateRegistryUrl({
+        provider: 'url',
+        url: directUrl,
+        branch: '',
+        file: '',
+      }),
+    }
+  }
+
+  const provider = normalizeTemplateRegistryProvider(
+    args.registryProvider
+      || env[REGISTRY_ENV_KEYS.provider]
+      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.provider,
+  )
+
+  const repo = trimPath(
+    args.registryRepo
+      || env[REGISTRY_ENV_KEYS.repo]
+      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.repo
+      || '',
+  )
+
+  const branch = trimPath(
+    args.registryBranch
+      || env[REGISTRY_ENV_KEYS.branch]
+      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.branch,
+  )
+
+  const file = trimFile(
+    args.registryFile
+      || env[REGISTRY_ENV_KEYS.file]
+      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.file,
+  )
+
+  const resolvedUrl = buildTemplateRegistryUrl({
+    provider,
+    repo,
+    branch,
+    file,
+  })
+
+  return {
+    provider,
+    repo,
+    branch,
+    file,
+    resolvedUrl,
+  }
+}
+
+export const createTemplateCacheMeta = (
+  config: ResolvedTemplateRegistryConfig,
+): TemplateCacheMeta => {
+  return {
+    registryUrl: config.resolvedUrl,
+    provider: config.provider,
+    repo: config.repo,
+    branch: config.branch,
+    file: config.file,
+    updatedAt: new Date().toISOString(),
+  }
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -35,6 +35,15 @@ const PROVIDER_ALIASES: Record<string, TemplateRegistryProvider> = {
 const trimPath = (value: string) => value.replace(/^\/+|\/+$/g, '')
 const trimFile = (value: string) => value.replace(/^\/+/, '')
 const hasMeaningfulString = (value?: string) => Boolean(value?.trim())
+const getMeaningfulString = (...values: Array<string | undefined>) => {
+  for (const value of values) {
+    const normalized = value?.trim()
+
+    if (normalized) {
+      return normalized
+    }
+  }
+}
 
 export const normalizeTemplateRegistryProvider = (
   input?: string,
@@ -133,7 +142,10 @@ export const resolveTemplateRegistryConfig = (
   args: TemplateRegistryArgs = {},
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedTemplateRegistryConfig => {
-  const directUrl = args.registryUrl?.trim() || env[REGISTRY_ENV_KEYS.url]?.trim()
+  const directUrl = getMeaningfulString(
+    args.registryUrl,
+    env[REGISTRY_ENV_KEYS.url],
+  )
 
   if (directUrl) {
     return {
@@ -152,28 +164,35 @@ export const resolveTemplateRegistryConfig = (
   }
 
   const provider = normalizeTemplateRegistryProvider(
-    args.registryProvider
-      || env[REGISTRY_ENV_KEYS.provider]
-      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.provider,
+    getMeaningfulString(
+      args.registryProvider,
+      env[REGISTRY_ENV_KEYS.provider],
+      DEFAULT_TEMPLATE_REGISTRY_CONFIG.provider,
+    ),
   )
 
   const repo = trimPath(
-    args.registryRepo
-      || env[REGISTRY_ENV_KEYS.repo]
-      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.repo
-      || '',
+    getMeaningfulString(
+      args.registryRepo,
+      env[REGISTRY_ENV_KEYS.repo],
+      DEFAULT_TEMPLATE_REGISTRY_CONFIG.repo,
+    ) || '',
   )
 
   const branch = trimPath(
-    args.registryBranch
-      || env[REGISTRY_ENV_KEYS.branch]
-      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.branch,
+    getMeaningfulString(
+      args.registryBranch,
+      env[REGISTRY_ENV_KEYS.branch],
+      DEFAULT_TEMPLATE_REGISTRY_CONFIG.branch,
+    ) || '',
   )
 
   const file = trimFile(
-    args.registryFile
-      || env[REGISTRY_ENV_KEYS.file]
-      || DEFAULT_TEMPLATE_REGISTRY_CONFIG.file,
+    getMeaningfulString(
+      args.registryFile,
+      env[REGISTRY_ENV_KEYS.file],
+      DEFAULT_TEMPLATE_REGISTRY_CONFIG.file,
+    ) || '',
   )
 
   const resolvedUrl = buildTemplateRegistryUrl({

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,8 +9,6 @@ export async function runCommand (
   argv: string[] = process.argv.slice(2),
   data: { overrides?: Record<string, any> } = {}
 ) {
-  argv.push('--no-clear') // Dev
-
   if (!(name in commands)) {
     throw new Error(`Invalid command ${name}`)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,48 @@
-export type SelectOption = {
+export type TemplateOption = {
+  name: string
   label: string
   value: string
   hint?: string
+  url?: string
+  tar?: string
+  source?: string
+  defaultDir?: string
+}
+
+export type TemplateRegistry = Record<string, TemplateOption>
+
+export type TemplateRegistryProvider = 'github' | 'gitlab' | 'gitee' | 'url'
+
+export type TemplateRegistryArgs = {
+  registryUrl?: string
+  registryProvider?: string
+  registryRepo?: string
+  registryBranch?: string
+  registryFile?: string
+}
+
+export type TemplateRegistryConfig = {
+  provider: TemplateRegistryProvider
+  repo?: string
+  branch: string
+  file: string
+  url?: string
+}
+
+export type ResolvedTemplateRegistryConfig = TemplateRegistryConfig & {
+  resolvedUrl: string
+}
+
+export type TemplateCacheMeta = {
+  registryUrl: string
+  provider: TemplateRegistryProvider
+  repo?: string
+  branch: string
+  file: string
+  updatedAt: string
+}
+
+export type TemplateCacheData = {
+  meta?: TemplateCacheMeta
+  templates: TemplateRegistry
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -234,10 +234,18 @@ export const resolveTemplateDirFromUrl = (value: string) => {
     const index = segments.indexOf(marker)
 
     if (index > 0) {
-      const archiveDir = sanitizeTemplateDirName(segments[index - 1])
+      for (let segmentIndex = index - 1; segmentIndex >= 0; segmentIndex--) {
+        const segment = segments[segmentIndex]
 
-      if (archiveDir) {
-        return archiveDir
+        if (segment === '-') {
+          continue
+        }
+
+        const archiveDir = sanitizeTemplateDirName(segment)
+
+        if (archiveDir) {
+          return archiveDir
+        }
       }
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,6 +29,15 @@ export const isExist = async (path: string) => {
   }
 }
 
+export const isFile = async (path: string) => {
+  try {
+    const stats = await stat(path)
+    return stats.isFile()
+  } catch (error) {
+    return false
+  }
+}
+
 export const HOME =
   process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'] || '/'
   

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,7 +4,7 @@ import { join } from 'pathe'
 import type { DownloadTemplateOptions } from 'giget'
 import { downloadTemplate } from 'giget'
 import ini from 'ini'
-import { resolveTemplateRegistryConfig } from '../registry'
+import { normalizeTemplateRegistryProvider, resolveTemplateRegistryConfig } from '../registry'
 import {
   ResolvedTemplateRegistryConfig,
   TemplateCacheData,
@@ -140,6 +140,20 @@ export const normalizeTemplateInfo = (input: Record<string, unknown>): TemplateR
   }, {} as TemplateRegistry)
 }
 
+const normalizeTemplateCacheProvider = (value: unknown): TemplateCacheMeta['provider'] => {
+  const provider = readMeaningfulString(value)
+
+  if (!provider) {
+    return 'github'
+  }
+
+  try {
+    return normalizeTemplateRegistryProvider(provider)
+  } catch {
+    return 'github'
+  }
+}
+
 const normalizeTemplateCacheMeta = (input: unknown): TemplateCacheMeta | undefined => {
   if (!input || typeof input !== 'object') {
     return undefined
@@ -154,9 +168,7 @@ const normalizeTemplateCacheMeta = (input: unknown): TemplateCacheMeta | undefin
 
   return {
     registryUrl,
-    provider: readMeaningfulString(value.provider)
-      ? readMeaningfulString(value.provider) as TemplateCacheMeta['provider']
-      : 'github',
+    provider: normalizeTemplateCacheProvider(value.provider),
     repo: readMeaningfulString(value.repo),
     branch: readMeaningfulString(value.branch) || '',
     file: readMeaningfulString(value.file) || '',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -228,7 +228,7 @@ export const resolveTemplateDirFromUrl = (value: string) => {
   const normalizedUrl = normalizeDownloadUrl(value)
   const { pathname } = new URL(normalizedUrl)
   const segments = pathname.split('/').filter(Boolean)
-  const archiveMarkers = ['archive', 'repository']
+  const archiveMarkers = ['repository', 'archive']
 
   for (const marker of archiveMarkers) {
     const index = segments.indexOf(marker)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -69,6 +69,8 @@ interface TemplateOptions extends DownloadTemplateOptions {
   templateInfo?: TemplateOption
 }
 
+const ARCHIVE_URL_RE = /\.(tar\.gz|tgz|zip)(?:$|[?#])/i
+
 const TEMPLATE_OPTION_FIELDS = ['name', 'label', 'value', 'hint', 'url', 'tar', 'source', 'defaultDir'] as const
 
 const readMeaningfulString = (value: unknown) => {
@@ -178,6 +180,74 @@ const normalizeTemplateGitSource = (value?: string) => {
   }
 
   return undefined
+}
+
+export const normalizeDownloadUrl = (value: string) => {
+  try {
+    const url = new URL(value)
+
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      throw new Error('download url must use http or https')
+    }
+
+    return url.toString()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'download url must use http or https') {
+      throw error
+    }
+
+    throw new Error(`invalid download url: ${value}`)
+  }
+}
+
+const sanitizeTemplateDirName = (value?: string) => {
+  const normalized = readMeaningfulString(value)
+
+  if (!normalized) {
+    return undefined
+  }
+
+  return normalized
+    .replace(/\.(tar\.gz|tgz|zip)$/i, '')
+    .replace(/\.git$/i, '')
+}
+
+export const resolveTemplateDirFromUrl = (value: string) => {
+  const normalizedUrl = normalizeDownloadUrl(value)
+  const { pathname } = new URL(normalizedUrl)
+  const segments = pathname.split('/').filter(Boolean)
+  const archiveMarkers = ['archive', 'repository']
+
+  for (const marker of archiveMarkers) {
+    const index = segments.indexOf(marker)
+
+    if (index > 0) {
+      const archiveDir = sanitizeTemplateDirName(segments[index - 1])
+
+      if (archiveDir) {
+        return archiveDir
+      }
+    }
+  }
+
+  return sanitizeTemplateDirName(segments.at(-1)) || 'template'
+}
+
+export const createTemplateInfoFromUrl = (value: string, templateName: string): TemplateOption => {
+  const normalizedUrl = normalizeDownloadUrl(value)
+  const templateInfo: TemplateOption = {
+    name: templateName,
+    label: templateName,
+    value: templateName,
+  }
+
+  if (ARCHIVE_URL_RE.test(normalizedUrl)) {
+    templateInfo.tar = normalizedUrl
+    return templateInfo
+  }
+
+  templateInfo.url = normalizedUrl
+  return templateInfo
 }
 
 const resolveTemplateSource = (templateInfo: TemplateOption, templateName: string) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,17 @@
 import consola from 'consola'
-import { stat, rm, readFile, writeFile } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'pathe'
-import { DownloadTemplateOptions, downloadTemplate } from 'giget'
-import { SelectOption } from '../types'
+import { stat, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'pathe'
+import type { DownloadTemplateOptions } from 'giget'
+import { downloadTemplate } from 'giget'
 import ini from 'ini'
+import { resolveTemplateRegistryConfig } from '../registry'
+import {
+  ResolvedTemplateRegistryConfig,
+  TemplateCacheData,
+  TemplateCacheMeta,
+  TemplateOption,
+  TemplateRegistry,
+} from '../types'
 
 // import { createDefu } from 'defu'
 
@@ -22,13 +29,6 @@ export const isExist = async (path: string) => {
   }
 }
 
-export const removeDir = async (path: string) => {
-  return rm(path, { recursive: true, force: true })
-}
-
-export const __filename = fileURLToPath(import.meta.url)
-export const __dirname = dirname(__filename)
-
 export const HOME =
   process.env[process.platform === 'win32' ? 'USERPROFILE' : 'HOME'] || '/'
   
@@ -36,6 +36,7 @@ export const HOME =
 export const COPYJSON = join(HOME, '.ccopyrc')
 
 export const gigetDir = join(HOME, '.cache', 'giget')
+export const TEMPLATE_CACHE_META_KEY = '__ccopy__'
 
 export async function confirm (path: string) {
   const isConfirm = await consola.prompt(
@@ -56,55 +57,248 @@ export async function confirm (path: string) {
 
 interface TemplateOptions extends DownloadTemplateOptions {
   template?: string
-  fileName?: string
+  templateInfo?: TemplateOption
+}
+
+const TEMPLATE_OPTION_FIELDS = ['name', 'label', 'value', 'hint', 'url', 'tar', 'source', 'defaultDir'] as const
+
+const readMeaningfulString = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const normalized = value.trim()
+
+  if (!normalized || normalized === 'undefined' || normalized === 'null') {
+    return undefined
+  }
+
+  return normalized
+}
+
+const compactIniSection = (value: Record<string, unknown>) => {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => {
+    return item !== undefined
+  }))
+}
+
+const normalizeTemplateOption = (key: string, input: unknown): TemplateOption | null => {
+  if (!input || typeof input !== 'object') {
+    return null
+  }
+
+  if (key === TEMPLATE_CACHE_META_KEY) {
+    return null
+  }
+
+  const value = input as Record<string, unknown>
+
+  const hasTemplateField = TEMPLATE_OPTION_FIELDS.some(field => {
+    return Boolean(readMeaningfulString(value[field]))
+  })
+
+  if (!hasTemplateField) {
+    return null
+  }
+
+  const templateName = readMeaningfulString(value.name)
+
+  const templateValue = readMeaningfulString(value.value) || templateName || key
+
+  return {
+    name: templateName || templateValue,
+    label: readMeaningfulString(value.label) || templateValue,
+    value: templateValue,
+    hint: readMeaningfulString(value.hint),
+    url: readMeaningfulString(value.url),
+    tar: readMeaningfulString(value.tar),
+    source: readMeaningfulString(value.source),
+    defaultDir: readMeaningfulString(value.defaultDir),
+  }
+}
+
+export const normalizeTemplateInfo = (input: Record<string, unknown>): TemplateRegistry => {
+  return Object.entries(input).reduce((registry, [key, value]) => {
+    const template = normalizeTemplateOption(key, value)
+
+    if (template) {
+      registry[template.value] = template
+    }
+
+    return registry
+  }, {} as TemplateRegistry)
+}
+
+const normalizeTemplateCacheMeta = (input: unknown): TemplateCacheMeta | undefined => {
+  if (!input || typeof input !== 'object') {
+    return undefined
+  }
+
+  const value = input as Record<string, unknown>
+  const registryUrl = readMeaningfulString(value.registryUrl)
+
+  if (!registryUrl) {
+    return undefined
+  }
+
+  return {
+    registryUrl,
+    provider: readMeaningfulString(value.provider)
+      ? readMeaningfulString(value.provider) as TemplateCacheMeta['provider']
+      : 'github',
+    repo: readMeaningfulString(value.repo),
+    branch: readMeaningfulString(value.branch) || '',
+    file: readMeaningfulString(value.file) || '',
+    updatedAt: readMeaningfulString(value.updatedAt) || '',
+  }
+}
+
+const normalizeTemplateGitSource = (value?: string) => {
+  const input = value?.trim()
+
+  if (!input) {
+    return undefined
+  }
+
+  if (/^(git|github|gh|gitlab|bitbucket|sourcehut)(\+git)?:/i.test(input)) {
+    return input
+  }
+
+  if (/^https?:\/\//i.test(input)) {
+    return `git:${input}`
+  }
+
+  return undefined
+}
+
+const resolveTemplateSource = (templateInfo: TemplateOption, templateName: string) => {
+  if (templateInfo.source) {
+    return templateInfo.source
+  }
+
+  if (templateInfo.tar) {
+    return templateInfo.tar
+  }
+
+  const gitSource = normalizeTemplateGitSource(templateInfo.url)
+
+  if (gitSource) {
+    return gitSource
+  }
+
+  return `github:xjccc-team/${templateName}`
 }
 
 export const getTemplate = async (options: TemplateOptions) => {
-  const { dir = '', template = dir, fileName = '' } = options
-  const cwd = options.cwd || process.cwd() || '.'
+  const {
+    dir = '',
+    template = dir,
+    templateInfo,
+    cwd = process.cwd() || '.',
+    ...downloadOptions
+  } = options
   const path = join(cwd, dir)
 
-  if (await isExist(path)) {
-    options.forceClean = await confirm(path)
+  let forceClean = downloadOptions.forceClean
+
+  if (dir && await isExist(path)) {
+    forceClean = await confirm(path)
   }
+
   if (!template) {
     consola.error('--template or -t to get template')
     process.exit(1)
   }
 
-  const defaultGithub = `github:xjccc-team/${template}`
+  const resolvedTemplateInfo = templateInfo || {
+    name: template,
+    label: template,
+    value: template,
+  }
 
-  const source = fileName ? fileName : defaultGithub
+  const source = resolveTemplateSource(resolvedTemplateInfo, template)
 
   return await downloadTemplate(source, {
-    ...options,
+    ...downloadOptions,
+    forceClean,
     cwd,
     dir
   })
 }
 
-export async function downloadTemplateInfo () {
-  const { dir } = await getTemplate({
-    template: 'template-infos',
-    // fileName: 'files:templates.json',
-    // providers: { files },
-    dir: '__temp__',
-    force: true
-  })
+export async function downloadTemplateInfo (
+  registryConfig: ResolvedTemplateRegistryConfig = resolveTemplateRegistryConfig(),
+) {
+  const response = await fetch(registryConfig.resolvedUrl)
 
-  const json = await readFile(join(dir, 'templates.json'), {
-    encoding: 'utf8'
-  })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch template info: ${response.status} ${response.statusText}`)
+  }
 
-  const data = (JSON.parse(json) as SelectOption[]).reduce((prev, next) => {
-    prev[next.value] = next
-    return prev
-  }, {} as { [key: string]: SelectOption })
+  const payload = await response.json()
 
-  await removeDir(dir)
+  if (!Array.isArray(payload)) {
+    throw new TypeError('Invalid template info format, expected an array')
+  }
+
+  const data = payload.reduce((registry, item) => {
+    if (!item || typeof item !== 'object') {
+      return registry
+    }
+
+    const template = normalizeTemplateOption('', item)
+
+    if (template?.value) {
+      registry[template.value] = template
+    }
+
+    return registry
+  }, {} as TemplateRegistry)
+
+  if (!Object.keys(data).length) {
+    throw new Error('Template info is empty')
+  }
+
   return data
 }
 
-export async function writeDefaultTemplateInfo (data: { [key: string]: SelectOption }) {
-  await writeFile(COPYJSON, ini.stringify(data))
+export async function readTemplateCache (): Promise<TemplateCacheData> {
+  const data = await readFile(COPYJSON, {
+    encoding: 'utf8'
+  })
+
+  const parsed = ini.parse(data) as Record<string, unknown>
+
+  return {
+    meta: normalizeTemplateCacheMeta(parsed[TEMPLATE_CACHE_META_KEY]),
+    templates: normalizeTemplateInfo(parsed),
+  }
+}
+
+export async function writeTemplateCache ({
+  meta,
+  templates,
+}: TemplateCacheData) {
+  const payload = Object.entries(templates).reduce((result, [key, value]) => {
+    result[key] = compactIniSection(value)
+    return result
+  }, {} as Record<string, unknown>)
+
+  if (meta) {
+    payload[TEMPLATE_CACHE_META_KEY] = compactIniSection(meta as unknown as Record<string, unknown>)
+  }
+
+  await writeFile(COPYJSON, ini.stringify(payload), {
+    encoding: 'utf8'
+  })
+}
+
+export async function writeDefaultTemplateInfo (
+  data: TemplateRegistry,
+  meta?: TemplateCacheMeta,
+) {
+  await writeTemplateCache({
+    meta,
+    templates: data,
+  })
 }

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -128,6 +128,7 @@ describe('create command', () => {
 
     silenceConsola()
     vi.stubEnv('INIT_CWD', invocationCwd)
+    vi.stubEnv('C_COPY_REGISTRY_PROVIDER', 'invalid-provider')
 
     const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
     const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo')

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { LogLevels, consola } from 'consola'
@@ -92,6 +92,32 @@ describe('create command', () => {
     expect(getTemplateSpy).not.toHaveBeenCalled()
     expect(consola.error).toHaveBeenCalledWith(
       'offline mode cannot use cache from another registry, run `c-copy update` first',
+    )
+  })
+
+  it('treats a .ccopyrc directory as missing cache instead of reading it as a file', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    await mkdir(utils.COPYJSON)
+
+    const readTemplateCacheSpy = vi.spyOn(utils, 'readTemplateCache')
+    const exitSpy = mockProcessExit()
+
+    await expect(create.run!({
+      args: {
+        cwd: home,
+        template: 'demo',
+        force: false,
+        offline: true,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(readTemplateCacheSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith(
+      'offline mode requires cached template info, run `c-copy update` first',
     )
   })
 

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { LogLevels, consola } from 'consola'
@@ -215,6 +215,33 @@ describe('create command', () => {
     expect(consola.error).toHaveBeenCalledWith('registry options cannot be used together with --url')
   })
 
+  it('ignores whitespace-only registry arguments when used with --url', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        url: 'https://github.com/acme/demo-template.git',
+        registryProvider: '   ',
+        registryRepo: '   ',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: expect.objectContaining({
+        url: 'https://github.com/acme/demo-template.git',
+      }),
+    }))
+    expect(consola.error).not.toHaveBeenCalled()
+  })
+
   it('refreshes cache and uses new template info when registry changes', async () => {
     const home = await createTempHome()
     const { create, registry, utils } = await loadModules(home)
@@ -313,6 +340,30 @@ describe('create command', () => {
     expect(getTemplateSpy).toHaveBeenCalledOnce()
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(consola.error).toHaveBeenCalledWith('download failed')
+  })
+
+  it('reports cache read failures with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    await writeFile(utils.COPYJSON, '')
+
+    const readTemplateCacheSpy = vi.spyOn(utils, 'readTemplateCache').mockRejectedValue(new Error('cache read failed'))
+    const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo')
+    const exitSpy = mockProcessExit()
+
+    await expect(create.run!({
+      args: {
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(readTemplateCacheSpy).toHaveBeenCalledOnce()
+    expect(downloadTemplateInfoSpy).not.toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('cache read failed')
   })
 
   it('passes --force through to registry template downloads', async () => {

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -121,6 +121,77 @@ describe('create command', () => {
     )
   })
 
+  it('downloads directly from --url without requiring registry cache', async () => {
+    const home = await createTempHome()
+    const invocationCwd = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('INIT_CWD', invocationCwd)
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+    const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo')
+
+    await create.run!({
+      args: {
+        cwd: './projects',
+        url: 'https://github.com/acme/demo-template.git',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(downloadTemplateInfoSpy).not.toHaveBeenCalled()
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: resolve(invocationCwd, './projects'),
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: expect.objectContaining({
+        url: 'https://github.com/acme/demo-template.git',
+      }),
+    }))
+  })
+
+  it('rejects mixing --url with template or registry arguments', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+    const exitSpy = mockProcessExit()
+
+    await expect(create.run!({
+      args: {
+        url: 'https://github.com/acme/demo-template.git',
+        template: 'demo',
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(getTemplateSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith('--template cannot be used together with --url')
+
+    vi.restoreAllMocks()
+    silenceConsola()
+    const secondExitSpy = mockProcessExit()
+    const secondGetTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await expect(create.run!({
+      args: {
+        url: 'https://github.com/acme/demo-template.git',
+        registryProvider: 'gitlab',
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(secondExitSpy).toHaveBeenCalledWith(1)
+    expect(secondGetTemplateSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith('registry options cannot be used together with --url')
+  })
+
   it('refreshes cache and uses new template info when registry changes', async () => {
     const home = await createTempHome()
     const { create, registry, utils } = await loadModules(home)

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1,0 +1,363 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { LogLevels, consola } from 'consola'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+const defaultConsolaLevel = consola.level
+
+const createTempHome = async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'c-copy-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const loadModules = async (home: string) => {
+  vi.resetModules()
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('USERPROFILE', home)
+
+  const registry = await import('../src/registry')
+  const utils = await import('../src/utils/index')
+  const create = (await import('../src/commands/create')).default
+
+  return {
+    create,
+    registry,
+    utils,
+  }
+}
+
+const silenceConsola = () => {
+  vi.spyOn(consola, 'start').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'success').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'warn').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'error').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'box').mockImplementation(() => '')
+}
+
+const mockProcessExit = () => {
+  return vi.spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('process.exit')
+  }) as never)
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+  consola.level = defaultConsolaLevel
+
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('create command', () => {
+  it('rejects offline create when cache belongs to another registry', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo',
+        label: 'Demo',
+        value: 'demo',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+    const exitSpy = mockProcessExit()
+
+    await expect(create.run!({
+      args: {
+        cwd: home,
+        template: 'demo',
+        force: false,
+        offline: true,
+        registryProvider: 'gitlab',
+        registryRepo: 'team/template-infos',
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(getTemplateSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith(
+      'offline mode cannot use cache from another registry, run `c-copy update` first',
+    )
+  })
+
+  it('refreshes cache and uses new template info when registry changes', async () => {
+    const home = await createTempHome()
+    const { create, registry, utils } = await loadModules(home)
+
+    silenceConsola()
+    await utils.writeDefaultTemplateInfo({
+      legacy: {
+        name: 'legacy',
+        label: 'Legacy',
+        value: 'legacy',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const registryConfig = registry.resolveTemplateRegistryConfig({
+      registryProvider: 'gitlab',
+      registryRepo: 'team/template-infos',
+    }, {})
+
+    const refreshedTemplates = {
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        source: 'gitlab:team/demo-template',
+        defaultDir: 'starter-app',
+      }
+    }
+
+    const downloadSpy = vi.spyOn(utils, 'downloadTemplateInfo').mockResolvedValue(refreshedTemplates)
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        cwd: home,
+        template: 'demo',
+        name: 'my-app',
+        force: false,
+        offline: false,
+        registryProvider: 'gitlab',
+        registryRepo: 'team/template-infos',
+      }
+    } as never)
+
+    expect(downloadSpy).toHaveBeenCalledWith(registryConfig)
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: home,
+      dir: 'my-app',
+      template: 'demo',
+      templateInfo: refreshedTemplates.demo,
+    }))
+
+    const cache = await utils.readTemplateCache()
+    expect(cache.meta?.registryUrl).toBe(registryConfig.resolvedUrl)
+    expect(cache.templates).toEqual(refreshedTemplates)
+  })
+
+  it('uses template defaultDir when name is omitted', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        cwd: home,
+        template: 'demo',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: home,
+      dir: 'starter-app',
+      template: 'demo',
+    }))
+  })
+
+  it('applies the requested log level before downloading', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockImplementation(async () => {
+      expect(consola.level).toBe(LogLevels.warn)
+      return {} as never
+    })
+
+    await create.run!({
+      args: {
+        cwd: home,
+        template: 'demo',
+        logLevel: 'warn',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledOnce()
+  })
+
+  it('uses INIT_CWD as the default target directory when invoked through pnpm', async () => {
+    const home = await createTempHome()
+    const invocationCwd = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('INIT_CWD', invocationCwd)
+
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        template: 'demo',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: invocationCwd,
+      dir: 'starter-app',
+      template: 'demo',
+    }))
+  })
+
+  it('resolves relative --cwd from INIT_CWD when invoked through pnpm', async () => {
+    const home = await createTempHome()
+    const invocationCwd = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('INIT_CWD', invocationCwd)
+
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        cwd: './projects',
+        template: 'demo',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: resolve(invocationCwd, './projects'),
+      dir: 'starter-app',
+      template: 'demo',
+    }))
+  })
+
+  it('falls back to PWD when INIT_CWD is missing', async () => {
+    const home = await createTempHome()
+    const invocationCwd = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('INIT_CWD', '')
+    vi.stubEnv('PWD', invocationCwd)
+
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        template: 'demo',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: invocationCwd,
+      dir: 'starter-app',
+      template: 'demo',
+    }))
+  })
+})

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -153,6 +153,28 @@ describe('create command', () => {
     }))
   })
 
+  it('reports registry resolution errors with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('C_COPY_REGISTRY_PROVIDER', 'invalid-provider')
+
+    const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo')
+    const exitSpy = mockProcessExit()
+
+    await expect(create.run!({
+      args: {
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(downloadTemplateInfoSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith('Unsupported template registry provider: invalid-provider')
+  })
+
   it('rejects mixing --url with template or registry arguments', async () => {
     const home = await createTempHome()
     const { create, utils } = await loadModules(home)
@@ -254,6 +276,43 @@ describe('create command', () => {
     const cache = await utils.readTemplateCache()
     expect(cache.meta?.registryUrl).toBe(registryConfig.resolvedUrl)
     expect(cache.templates).toEqual(refreshedTemplates)
+  })
+
+  it('reports template download failures with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }, {
+      registryUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockRejectedValue(new Error('download failed'))
+    const exitSpy = mockProcessExit()
+
+    await expect(create.run!({
+      args: {
+        template: 'demo',
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(getTemplateSpy).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('download failed')
   })
 
   it('uses template defaultDir when name is omitted', async () => {

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -315,6 +315,38 @@ describe('create command', () => {
     expect(consola.error).toHaveBeenCalledWith('download failed')
   })
 
+  it('passes --force through to registry template downloads', async () => {
+    const home = await createTempHome()
+    const { create, utils } = await loadModules(home)
+
+    silenceConsola()
+    const refreshedTemplates = {
+      demo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo',
+        defaultDir: 'starter-app',
+      }
+    }
+
+    vi.spyOn(utils, 'downloadTemplateInfo').mockResolvedValue(refreshedTemplates)
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await create.run!({
+      args: {
+        template: 'demo',
+        force: true,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      force: true,
+      dir: 'starter-app',
+      template: 'demo',
+    }))
+  })
+
   it('uses template defaultDir when name is omitted', async () => {
     const home = await createTempHome()
     const { create, utils } = await loadModules(home)

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -196,4 +196,25 @@ describe('download command', () => {
     expect(getTemplateSpy).not.toHaveBeenCalled()
     expect(consola.error).toHaveBeenCalledWith('invalid download url: git@github.com:acme/demo-template.git')
   })
+
+  it('reports non-Error download failures with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockRejectedValue('download failed')
+    const exitSpy = mockProcessExit()
+
+    await expect(download.run!({
+      args: {
+        url: 'https://github.com/acme/demo-template.git',
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(getTemplateSpy).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('download failed')
+  })
 })

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -106,6 +106,30 @@ describe('download command', () => {
     }))
   })
 
+  it('derives the repository directory name for gitee repository archive URLs', async () => {
+    const home = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await download.run!({
+      args: {
+        url: 'https://gitee.com/acme/demo-template/repository/archive/main.tar.gz',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: expect.objectContaining({
+        tar: 'https://gitee.com/acme/demo-template/repository/archive/main.tar.gz',
+      }),
+    }))
+  })
+
   it('applies the requested log level before downloading', async () => {
     const home = await createTempHome()
     const { download, utils } = await loadModules(home)

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { LogLevels, consola } from 'consola'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+const defaultConsolaLevel = consola.level
+
+const createTempHome = async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'c-copy-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const loadModules = async (home: string) => {
+  vi.resetModules()
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('USERPROFILE', home)
+
+  const utils = await import('../src/utils/index')
+  const download = (await import('../src/commands/download')).default
+
+  return {
+    download,
+    utils,
+  }
+}
+
+const silenceConsola = () => {
+  vi.spyOn(consola, 'start').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'success').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'warn').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'error').mockImplementation(() => consola as typeof consola)
+  vi.spyOn(consola, 'box').mockImplementation(() => '')
+}
+
+const mockProcessExit = () => {
+  return vi.spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('process.exit')
+  }) as never)
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+  consola.level = defaultConsolaLevel
+
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('download command', () => {
+  it('downloads a repository URL into the requested directory', async () => {
+    const home = await createTempHome()
+    const invocationCwd = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('INIT_CWD', invocationCwd)
+
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await download.run!({
+      args: {
+        cwd: './projects',
+        url: 'https://github.com/acme/demo-template.git',
+        name: 'my-app',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: resolve(invocationCwd, './projects'),
+      dir: 'my-app',
+      template: 'my-app',
+      templateInfo: expect.objectContaining({
+        url: 'https://github.com/acme/demo-template.git',
+      }),
+    }))
+  })
+
+  it('treats archive URLs as tarball downloads and derives the repository directory name', async () => {
+    const home = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await download.run!({
+      args: {
+        url: 'https://github.com/acme/demo-template/archive/refs/heads/main.tar.gz',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: expect.objectContaining({
+        tar: 'https://github.com/acme/demo-template/archive/refs/heads/main.tar.gz',
+      }),
+    }))
+  })
+
+  it('applies the requested log level before downloading', async () => {
+    const home = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockImplementation(async () => {
+      expect(consola.level).toBe(LogLevels.warn)
+      return {} as never
+    })
+
+    await download.run!({
+      args: {
+        url: 'https://github.com/acme/demo-template.git',
+        logLevel: 'warn',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledOnce()
+  })
+
+  it('rejects invalid download urls', async () => {
+    const home = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+    const exitSpy = mockProcessExit()
+
+    await expect(download.run!({
+      args: {
+        url: 'git@github.com:acme/demo-template.git',
+        force: false,
+        offline: false,
+      }
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(getTemplateSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith('invalid download url: git@github.com:acme/demo-template.git')
+  })
+})

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -130,6 +130,30 @@ describe('download command', () => {
     }))
   })
 
+  it('derives the repository directory name for gitlab archive URLs', async () => {
+    const home = await createTempHome()
+    const { download, utils } = await loadModules(home)
+
+    silenceConsola()
+    const getTemplateSpy = vi.spyOn(utils, 'getTemplate').mockResolvedValue({} as never)
+
+    await download.run!({
+      args: {
+        url: 'https://gitlab.com/acme/demo-template/-/archive/main/demo-template-main.tar.gz',
+        force: false,
+        offline: false,
+      }
+    } as never)
+
+    expect(getTemplateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: expect.objectContaining({
+        tar: 'https://gitlab.com/acme/demo-template/-/archive/main/demo-template-main.tar.gz',
+      }),
+    }))
+  })
+
   it('applies the requested log level before downloading', async () => {
     const home = await createTempHome()
     const { download, utils } = await loadModules(home)

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -85,4 +85,24 @@ describe('registry helpers', () => {
       C_COPY_REGISTRY_REPO: '   ',
     })).toBe(false)
   })
+
+  it('ignores whitespace-only resolver inputs before applying fallbacks', () => {
+    expect(resolveTemplateRegistryConfig({
+      registryProvider: '   ',
+      registryRepo: '   ',
+      registryBranch: '   ',
+      registryFile: '   ',
+    }, {
+      C_COPY_REGISTRY_PROVIDER: ' gitlab ',
+      C_COPY_REGISTRY_REPO: ' /team/template-infos/ ',
+      C_COPY_REGISTRY_BRANCH: ' /release/ ',
+      C_COPY_REGISTRY_FILE: ' /custom/templates.json ',
+    })).toEqual({
+      provider: 'gitlab',
+      repo: 'team/template-infos',
+      branch: 'release',
+      file: 'custom/templates.json',
+      resolvedUrl: 'https://gitlab.com/team/template-infos/-/raw/release/custom/templates.json',
+    })
+  })
 })

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -77,4 +77,12 @@ describe('registry helpers', () => {
       C_COPY_REGISTRY_PROVIDER: 'gitlab',
     })).toBe(true)
   })
+
+  it('ignores whitespace-only registry overrides', () => {
+    expect(hasTemplateRegistryOverride({
+      registryProvider: '   ',
+    }, {
+      C_COPY_REGISTRY_REPO: '   ',
+    })).toBe(false)
+  })
 })

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -54,6 +54,24 @@ describe('registry helpers', () => {
     })
   })
 
+  it('rejects malformed direct registry URLs with a clearer error', () => {
+    expect(() => buildTemplateRegistryUrl({
+      provider: 'url',
+      url: 'not-a-valid-url',
+      branch: '',
+      file: '',
+    })).toThrow('invalid registry url: not-a-valid-url')
+  })
+
+  it('rejects unsupported direct registry URL protocols', () => {
+    expect(() => buildTemplateRegistryUrl({
+      provider: 'url',
+      url: 'file:///tmp/templates.json',
+      branch: '',
+      file: '',
+    })).toThrow('invalid registry url protocol: file:. Only http: and https: are supported')
+  })
+
   it('detects registry overrides from environment variables', () => {
     expect(hasTemplateRegistryOverride({}, {
       C_COPY_REGISTRY_PROVIDER: 'gitlab',

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTemplateRegistryUrl,
+  hasTemplateRegistryOverride,
+  resolveTemplateRegistryConfig,
+} from '../src/registry'
+
+describe('registry helpers', () => {
+  it('uses the default templates.json registry when no custom url is provided', () => {
+    expect(resolveTemplateRegistryConfig({}, {})).toEqual({
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      resolvedUrl: 'https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+    })
+  })
+
+  it('builds registry URLs for github, gitlab and gitee', () => {
+    expect(buildTemplateRegistryUrl({
+      provider: 'github',
+      repo: 'xjccc-team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+    })).toBe('https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json')
+
+    expect(buildTemplateRegistryUrl({
+      provider: 'gitlab',
+      repo: 'team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+    })).toBe('https://gitlab.com/team/template-infos/-/raw/main/templates.json')
+
+    expect(buildTemplateRegistryUrl({
+      provider: 'gitee',
+      repo: 'team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+    })).toBe('https://gitee.com/team/template-infos/raw/main/templates.json')
+  })
+
+  it('prefers direct registry URL when provided', () => {
+    expect(resolveTemplateRegistryConfig({
+      registryUrl: 'https://example.com/templates.json',
+      registryProvider: 'gitlab',
+      registryRepo: 'team/template-infos',
+    }, {})).toEqual({
+      provider: 'url',
+      url: 'https://example.com/templates.json',
+      repo: undefined,
+      branch: '',
+      file: '',
+      resolvedUrl: 'https://example.com/templates.json',
+    })
+  })
+
+  it('detects registry overrides from environment variables', () => {
+    expect(hasTemplateRegistryOverride({}, {
+      C_COPY_REGISTRY_PROVIDER: 'gitlab',
+    })).toBe(true)
+  })
+})

--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import consola from 'consola'
@@ -60,5 +60,21 @@ describe('show command', () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(consola.error).toHaveBeenCalledWith('.ccopyrc was not found or is not a file')
+  })
+
+  it('reports cache read failures with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { show, utils } = await loadModules(home)
+
+    silenceConsola()
+    const exitSpy = mockProcessExit()
+
+    await writeFile(utils.COPYJSON, '')
+    vi.spyOn(utils, 'readTemplateCache').mockRejectedValue(new Error('cache read failed'))
+
+    await expect(show.run!({} as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('cache read failed')
   })
 })

--- a/test/show.test.ts
+++ b/test/show.test.ts
@@ -1,0 +1,64 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import consola from 'consola'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+
+const createTempHome = async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'c-copy-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const loadModules = async (home: string) => {
+  vi.resetModules()
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('USERPROFILE', home)
+
+  const utils = await import('../src/utils/index')
+  const show = (await import('../src/commands/show')).default
+
+  return {
+    show,
+    utils,
+  }
+}
+
+const silenceConsola = () => {
+  vi.spyOn(consola, 'info').mockImplementation(() => consola)
+  vi.spyOn(consola, 'error').mockImplementation(() => consola)
+}
+
+const mockProcessExit = () => {
+  return vi.spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('process.exit')
+  }) as never)
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('show command', () => {
+  it('reports when .ccopyrc exists but is not a file', async () => {
+    const home = await createTempHome()
+    const { show, utils } = await loadModules(home)
+
+    silenceConsola()
+    const exitSpy = mockProcessExit()
+
+    await mkdir(utils.COPYJSON)
+
+    await expect(show.run!({} as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('.ccopyrc was not found or is not a file')
+  })
+})

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -84,4 +84,22 @@ describe('update command', () => {
     expect(exitSpy).toHaveBeenCalledWith(1)
     expect(consola.error).toHaveBeenCalledWith('registry fetch failed')
   })
+
+  it('reports non-Error registry failures with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { update, utils } = await loadModules(home)
+
+    silenceConsola()
+
+    const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo').mockRejectedValue('registry fetch failed')
+    const exitSpy = mockProcessExit()
+
+    await expect(update.run!({
+      args: {}
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(downloadTemplateInfoSpy).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('registry fetch failed')
+  })
 })

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,0 +1,87 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import consola from 'consola'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const tempDirs: string[] = []
+
+const createTempHome = async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'c-copy-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const loadModules = async (home: string) => {
+  vi.resetModules()
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('USERPROFILE', home)
+
+  const utils = await import('../src/utils/index')
+  const update = (await import('../src/commands/update')).default
+
+  return {
+    update,
+    utils,
+  }
+}
+
+const silenceConsola = () => {
+  vi.spyOn(consola, 'start').mockImplementation(() => consola)
+  vi.spyOn(consola, 'success').mockImplementation(() => consola)
+  vi.spyOn(consola, 'error').mockImplementation(() => consola)
+}
+
+const mockProcessExit = () => {
+  return vi.spyOn(process, 'exit').mockImplementation((() => {
+    throw new Error('process.exit')
+  }) as never)
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('update command', () => {
+  it('reports registry resolution errors with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { update, utils } = await loadModules(home)
+
+    silenceConsola()
+    vi.stubEnv('C_COPY_REGISTRY_PROVIDER', 'invalid-provider')
+
+    const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo')
+    const exitSpy = mockProcessExit()
+
+    await expect(update.run!({
+      args: {}
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(downloadTemplateInfoSpy).not.toHaveBeenCalled()
+    expect(consola.error).toHaveBeenCalledWith('Unsupported template registry provider: invalid-provider')
+  })
+
+  it('reports registry download failures with a clean CLI message', async () => {
+    const home = await createTempHome()
+    const { update, utils } = await loadModules(home)
+
+    silenceConsola()
+
+    const downloadTemplateInfoSpy = vi.spyOn(utils, 'downloadTemplateInfo').mockRejectedValue(new Error('registry fetch failed'))
+    const exitSpy = mockProcessExit()
+
+    await expect(update.run!({
+      args: {}
+    } as never)).rejects.toThrow('process.exit')
+
+    expect(downloadTemplateInfoSpy).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(consola.error).toHaveBeenCalledWith('registry fetch failed')
+  })
+})

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -239,6 +239,45 @@ describe('utils', () => {
     )
   })
 
+  it('normalizes cached registry providers and falls back for invalid values', async () => {
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await writeFile(utils.COPYJSON, [
+      '[demo-template]',
+      'name=demo-template',
+      'label=Demo',
+      'value=demo-template',
+      '',
+      '[__ccopy__]',
+      'registryUrl=https://example.com/templates.json',
+      'provider=gl',
+      'repo=team/template-infos',
+      'branch=main',
+      'file=templates.json',
+      '',
+    ].join('\n'))
+
+    expect((await utils.readTemplateCache()).meta?.provider).toBe('gitlab')
+
+    await writeFile(utils.COPYJSON, [
+      '[demo-template]',
+      'name=demo-template',
+      'label=Demo',
+      'value=demo-template',
+      '',
+      '[__ccopy__]',
+      'registryUrl=https://example.com/templates.json',
+      'provider=unexpected-provider',
+      'repo=team/template-infos',
+      'branch=main',
+      'file=templates.json',
+      '',
+    ].join('\n'))
+
+    expect((await utils.readTemplateCache()).meta?.provider).toBe('github')
+  })
+
   it('downloads template info from the resolved registry URL', async () => {
     const home = await createTempHome()
     const utils = await loadUtils(home)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -42,6 +42,21 @@ afterEach(async () => {
 })
 
 describe('utils', () => {
+  it('distinguishes regular files from directories', async () => {
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await mkdir(utils.COPYJSON)
+
+    expect(await utils.isExist(utils.COPYJSON)).toBe(true)
+    expect(await utils.isFile(utils.COPYJSON)).toBe(false)
+
+    await rm(utils.COPYJSON, { recursive: true, force: true })
+    await writeFile(utils.COPYJSON, '')
+
+    expect(await utils.isFile(utils.COPYJSON)).toBe(true)
+  })
+
   it('persists template cache metadata separately from templates', async () => {
     const home = await createTempHome()
     const utils = await loadUtils(home)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,264 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { downloadTemplateMock } = vi.hoisted(() => {
+  return {
+    downloadTemplateMock: vi.fn(),
+  }
+})
+
+vi.mock('giget', () => {
+  return {
+    downloadTemplate: downloadTemplateMock,
+  }
+})
+
+const tempDirs: string[] = []
+
+const createTempHome = async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'c-copy-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const loadUtils = async (home: string) => {
+  vi.resetModules()
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('USERPROFILE', home)
+
+  return await import('../src/utils/index')
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+  downloadTemplateMock.mockReset()
+
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+describe('utils', () => {
+  it('persists template cache metadata separately from templates', async () => {
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await utils.writeDefaultTemplateInfo({
+      demo: {
+        name: 'demo',
+        label: 'Demo',
+        value: 'demo',
+        tar: 'https://example.com/demo.tar.gz',
+        defaultDir: 'demo-app',
+      }
+    }, {
+      registryUrl: 'https://gitlab.com/team/template-infos/-/raw/main/templates.json',
+      provider: 'gitlab',
+      repo: 'team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      updatedAt: '2026-04-14T00:00:00.000Z',
+    })
+
+    const cache = await utils.readTemplateCache()
+
+    expect(cache.meta?.registryUrl).toBe('https://gitlab.com/team/template-infos/-/raw/main/templates.json')
+    expect(cache.templates).toEqual({
+      demo: {
+        name: 'demo',
+        label: 'Demo',
+        value: 'demo',
+        tar: 'https://example.com/demo.tar.gz',
+        defaultDir: 'demo-app',
+      }
+    })
+
+    const raw = await readFile(utils.COPYJSON, 'utf8')
+    expect(raw).not.toContain('source=undefined')
+  })
+
+  it('prefers explicit source when downloading templates', async () => {
+    downloadTemplateMock.mockResolvedValue({
+      source: 'gitlab:team/demo-template',
+      dir: '/tmp/demo-template',
+    })
+
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await utils.getTemplate({
+      cwd: home,
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo-template',
+        source: 'gitlab:team/demo-template',
+      },
+    })
+
+    expect(downloadTemplateMock).toHaveBeenCalledWith(
+      'gitlab:team/demo-template',
+      expect.objectContaining({
+        cwd: home,
+        dir: 'demo-template',
+      }),
+    )
+  })
+
+  it('uses a tarball URL directly when registry item exposes tar', async () => {
+    downloadTemplateMock.mockResolvedValue({
+      source: 'https://gitee.com/team/demo-template/repository/archive/main.tar.gz',
+      dir: '/tmp/demo-template',
+    })
+
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await utils.getTemplate({
+      cwd: home,
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo-template',
+        tar: 'https://gitee.com/team/demo-template/repository/archive/main.tar.gz',
+        url: 'https://gitee.com/team/demo-template',
+        defaultDir: 'demo-template',
+      },
+    })
+
+    expect(downloadTemplateMock).toHaveBeenCalledWith(
+      'https://gitee.com/team/demo-template/repository/archive/main.tar.gz',
+      expect.objectContaining({
+        cwd: home,
+        dir: 'demo-template',
+      }),
+    )
+  })
+
+  it('uses template url from registry when tar and source are missing', async () => {
+    downloadTemplateMock.mockResolvedValue({
+      source: 'git:https://gitlab.com/team/demo-template',
+      dir: '/tmp/demo-template',
+    })
+
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await utils.getTemplate({
+      cwd: home,
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo-template',
+        url: 'https://gitlab.com/team/demo-template',
+      },
+    })
+
+    expect(downloadTemplateMock).toHaveBeenCalledWith(
+      'git:https://gitlab.com/team/demo-template',
+      expect.objectContaining({
+        cwd: home,
+        dir: 'demo-template',
+      }),
+    )
+  })
+
+  it('ignores legacy undefined strings in cached template fields', async () => {
+    downloadTemplateMock.mockResolvedValue({
+      source: 'https://example.com/demo-template.tar.gz',
+      dir: '/tmp/demo-template',
+    })
+
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+
+    await writeFile(utils.COPYJSON, [
+      '[demo-template]',
+      'name=demo-template',
+      'label=Demo',
+      'value=demo-template',
+      'source=undefined',
+      'tar=https://example.com/demo-template.tar.gz',
+      '',
+      '[__ccopy__]',
+      'registryUrl=https://raw.githubusercontent.com/xjccc-team/template-infos/main/templates.json',
+      'provider=github',
+      'repo=xjccc-team/template-infos',
+      'branch=main',
+      'file=templates.json',
+      'updatedAt=2026-04-14T00:00:00.000Z',
+      '',
+    ].join('\n'))
+
+    const cache = await utils.readTemplateCache()
+
+    expect(cache.templates['demo-template']).toEqual({
+      name: 'demo-template',
+      label: 'Demo',
+      value: 'demo-template',
+      tar: 'https://example.com/demo-template.tar.gz',
+    })
+
+    await utils.getTemplate({
+      cwd: home,
+      dir: 'demo-template',
+      template: 'demo-template',
+      templateInfo: cache.templates['demo-template'],
+    })
+
+    expect(downloadTemplateMock).toHaveBeenCalledWith(
+      'https://example.com/demo-template.tar.gz',
+      expect.objectContaining({
+        cwd: home,
+        dir: 'demo-template',
+      }),
+    )
+  })
+
+  it('downloads template info from the resolved registry URL', async () => {
+    const home = await createTempHome()
+    const utils = await loadUtils(home)
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          name: 'demo-template',
+          label: 'Demo',
+          value: 'demo-template',
+          tar: 'https://example.com/demo-template.tar.gz',
+          defaultDir: 'demo-template',
+        },
+      ],
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const data = await utils.downloadTemplateInfo({
+      provider: 'gitlab',
+      repo: 'team/template-infos',
+      branch: 'main',
+      file: 'templates.json',
+      resolvedUrl: 'https://gitlab.com/team/template-infos/-/raw/main/templates.json',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('https://gitlab.com/team/template-infos/-/raw/main/templates.json')
+    expect(data).toEqual({
+      'demo-template': {
+        name: 'demo-template',
+        label: 'Demo',
+        value: 'demo-template',
+        tar: 'https://example.com/demo-template.tar.gz',
+        defaultDir: 'demo-template',
+      }
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
     "strict": true,
     "noImplicitAny": true,
     "allowJs": true,
@@ -14,5 +12,5 @@
     "resolveJsonModule": true,
     "types": ["node"],
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/unbuild.config.ts
+++ b/unbuild.config.ts
@@ -4,8 +4,4 @@ export default defineBuildConfig({
   entries: ['src/index'],
   clean: true,
   declaration: true,
-  rollup: {
-    emitCJS: true,
-    inlineDependencies: true
-  }
 })


### PR DESCRIPTION
- support GitHub, GitLab, Gitee, and direct URL registries
- cache registry metadata in .ccopyrc and refresh automatically when the source changes
- fix create target directory resolution for pnpm INIT_CWD and honor --logLevel
- harden template source resolution and legacy cache compatibility
- add Vitest coverage for registry, cache, and create flows
- refresh README, bump package metadata to 1.0.0, and upgrade the Node 22 toolchain